### PR TITLE
Spectrum Tile

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     implementation("com.github.wendykierp:JTransforms:3.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-swing:1.7.1")
+    implementation("org.greenrobot:eventbus-java:3.3.1")
     implementation(compose.desktop.currentOs)
 
     // Unit Testing

--- a/src/main/kotlin/color/ColorFactory.kt
+++ b/src/main/kotlin/color/ColorFactory.kt
@@ -1,9 +1,7 @@
 package color
 
-import gui.dashboard.spectrumTileViewModel
 import input.audioFrame.AudioFrame
-import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.launch
+import org.greenrobot.eventbus.EventBus
 import sound.bins.frequency.BassBinsFactory
 import sound.bins.frequency.FrequencyBins
 import wrappers.color.Color
@@ -17,7 +15,7 @@ class ColorFactory(
     @Suppress("ReturnCount")
     fun create(audioFrame: AudioFrame): Color {
         val bassBins = bassBinsFactory.create(audioFrame)
-        MainScope().launch { spectrumTileViewModel.setFrequencyBins(bassBins) }
+        EventBus.getDefault().post(bassBins)
 
         val hue = getHue(bassBins) ?: return Color.black
         val brightness = getBrightness(bassBins) ?: return Color.black

--- a/src/main/kotlin/color/ColorFactory.kt
+++ b/src/main/kotlin/color/ColorFactory.kt
@@ -1,5 +1,6 @@
 package color
 
+import gui.dashboard.spectrumTileViewModel
 import input.audioFrame.AudioFrame
 import sound.bins.frequency.BassBinsFactory
 import sound.bins.frequency.FrequencyBins
@@ -14,6 +15,7 @@ class ColorFactory(
     @Suppress("ReturnCount")
     fun create(audioFrame: AudioFrame): Color {
         val bassBins = bassBinsFactory.create(audioFrame)
+        spectrumTileViewModel.updateFrequencyBins(bassBins)
 
         val hue = getHue(bassBins) ?: return Color.black
         val brightness = getBrightness(bassBins) ?: return Color.black

--- a/src/main/kotlin/color/ColorFactory.kt
+++ b/src/main/kotlin/color/ColorFactory.kt
@@ -2,6 +2,8 @@ package color
 
 import gui.dashboard.spectrumTileViewModel
 import input.audioFrame.AudioFrame
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
 import sound.bins.frequency.BassBinsFactory
 import sound.bins.frequency.FrequencyBins
 import wrappers.color.Color
@@ -15,7 +17,7 @@ class ColorFactory(
     @Suppress("ReturnCount")
     fun create(audioFrame: AudioFrame): Color {
         val bassBins = bassBinsFactory.create(audioFrame)
-        spectrumTileViewModel.updateFrequencyBins(bassBins)
+        MainScope().launch { spectrumTileViewModel.setFrequencyBins(bassBins) }
 
         val hue = getHue(bassBins) ?: return Color.black
         val brightness = getBrightness(bassBins) ?: return Color.black

--- a/src/main/kotlin/config/ConfigFactory.kt
+++ b/src/main/kotlin/config/ConfigFactory.kt
@@ -23,7 +23,7 @@ class ConfigFactory(
             ),
             sampleSize = 4410,
             interpolatedSampleSize = 65536,
-            magnitudeMultiplier = 2F,
+            magnitudeMultiplier = 4F,
             millisecondsToWaitBetweenCheckingForNewAudio = 1,
         )
     }

--- a/src/main/kotlin/gui/basicComponents/Bar.kt
+++ b/src/main/kotlin/gui/basicComponents/Bar.kt
@@ -1,0 +1,43 @@
+package gui.basicComponents
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+
+@Composable
+fun Bar(value: Float) {
+    Column {
+        val clearWeight = 1F - value
+
+        if (clearWeight > 0F) {
+            ClearBox(modifier = Modifier.weight(clearWeight))
+        }
+
+        if (value > 0F) {
+            ColoredBox(modifier = Modifier.weight(value))
+        }
+    }
+}
+
+@Composable
+private fun ClearBox(modifier: Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.Transparent)
+    )
+}
+
+@Composable
+private fun ColoredBox(modifier: Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colors.secondary)
+    )
+}

--- a/src/main/kotlin/gui/basicComponents/Grid.kt
+++ b/src/main/kotlin/gui/basicComponents/Grid.kt
@@ -1,0 +1,50 @@
+package gui.basicComponents
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+
+// TODO: X and Y axis labels
+// TODO: Scale subdivisions based on size
+@Composable
+fun Grid(
+    lineColor: Color = MaterialTheme.colors.primary,
+    content: @Composable () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(1000.dp)
+            .border(1.dp, lineColor)
+    ) {
+        content()
+        Canvas(modifier = Modifier.fillMaxSize().zIndex(1f)) {
+            drawGrid(this, lineColor)
+        }
+    }
+}
+
+fun drawGrid(scope: DrawScope, lineColor: Color) {
+    val strokeWidth = 1f
+    val horizontalLineInterval = scope.size.height / 10
+    val verticalLineInterval = scope.size.width / 10
+    for (i in 1 until 10) {
+        val y = i * horizontalLineInterval
+        scope.drawLine(lineColor, start = Offset(0f, y), end = Offset(scope.size.width, y), strokeWidth = strokeWidth)
+    }
+    for (i in 1 until 10) {
+        val x = i * verticalLineInterval
+        scope.drawLine(lineColor, start = Offset(x, 0f), end = Offset(x, scope.size.height), strokeWidth = strokeWidth)
+    }
+}

--- a/src/main/kotlin/gui/basicComponents/Grid.kt
+++ b/src/main/kotlin/gui/basicComponents/Grid.kt
@@ -4,8 +4,6 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -15,19 +13,11 @@ import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 
-// TODO: X and Y axis labels
-// TODO: Scale subdivisions based on size
 @Composable
-fun Grid(
-    lineColor: Color = MaterialTheme.colors.primary,
-    content: @Composable () -> Unit
-) {
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(1000.dp)
-            .border(1.dp, lineColor)
-    ) {
+fun Grid(content: @Composable () -> Unit) {
+    val lineColor = MaterialTheme.colors.primary
+
+    Box(modifier = Modifier.border(1.dp, lineColor)) {
         content()
         Canvas(modifier = Modifier.fillMaxSize().zIndex(1f)) {
             drawGrid(this, lineColor)
@@ -35,16 +25,48 @@ fun Grid(
     }
 }
 
-fun drawGrid(scope: DrawScope, lineColor: Color) {
-    val strokeWidth = 1f
-    val horizontalLineInterval = scope.size.height / 10
-    val verticalLineInterval = scope.size.width / 10
-    for (i in 1 until 10) {
-        val y = i * horizontalLineInterval
-        scope.drawLine(lineColor, start = Offset(0f, y), end = Offset(scope.size.width, y), strokeWidth = strokeWidth)
+fun drawGrid(
+    scope: DrawScope,
+    lineColor: Color,
+    horizontalLineCount: Int = 10,
+    verticalLineCount: Int = 10,
+) {
+    drawHorizontalLines(scope, lineColor, horizontalLineCount)
+    drawVerticalLines(scope, lineColor, verticalLineCount)
+}
+
+fun drawHorizontalLines(
+    scope: DrawScope,
+    lineColor: Color,
+    lineCount: Int
+) {
+    val lineInterval = scope.size.height / lineCount
+
+    repeat(lineCount) { index ->
+        val y = index * lineInterval
+
+        scope.drawLine(
+            color = lineColor,
+            start = Offset(0f, y),
+            end = Offset(scope.size.width, y)
+        )
     }
-    for (i in 1 until 10) {
-        val x = i * verticalLineInterval
-        scope.drawLine(lineColor, start = Offset(x, 0f), end = Offset(x, scope.size.height), strokeWidth = strokeWidth)
+}
+
+fun drawVerticalLines(
+    scope: DrawScope,
+    lineColor: Color,
+    lineCount: Int
+) {
+    val lineInterval = scope.size.width / lineCount
+
+    repeat(lineCount) { index ->
+        val x = index * lineInterval
+
+        scope.drawLine(
+            color = lineColor,
+            start = Offset(x, 0f),
+            end = Offset(x, scope.size.height)
+        )
     }
 }

--- a/src/main/kotlin/gui/basicComponents/Grid.kt
+++ b/src/main/kotlin/gui/basicComponents/Grid.kt
@@ -25,7 +25,7 @@ fun Grid(content: @Composable () -> Unit) {
     }
 }
 
-fun drawGrid(
+private fun drawGrid(
     scope: DrawScope,
     lineColor: Color,
     horizontalLineCount: Int = 10,
@@ -35,7 +35,7 @@ fun drawGrid(
     drawVerticalLines(scope, lineColor, verticalLineCount)
 }
 
-fun drawHorizontalLines(
+private fun drawHorizontalLines(
     scope: DrawScope,
     lineColor: Color,
     lineCount: Int
@@ -53,7 +53,7 @@ fun drawHorizontalLines(
     }
 }
 
-fun drawVerticalLines(
+private fun drawVerticalLines(
     scope: DrawScope,
     lineColor: Color,
     lineCount: Int

--- a/src/main/kotlin/gui/basicComponents/RowWithEqualColumnWidths.kt
+++ b/src/main/kotlin/gui/basicComponents/RowWithEqualColumnWidths.kt
@@ -1,0 +1,29 @@
+package gui.basicComponents
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun RowWithEqualColumnWidths(
+    children: List<@Composable () -> Unit>
+) {
+    if (children.isEmpty()) return
+
+    BoxWithConstraints {
+        val columnWidth = maxWidth / children.size
+
+        Row {
+            children.dropLast(1).forEach { child ->
+                Box(modifier = Modifier.width(columnWidth)) {
+                    child()
+                }
+            }
+
+            // Last child fills the remaining width
+            Box(modifier = Modifier.fillMaxWidth()) {
+                children.last()()
+            }
+        }
+    }
+}

--- a/src/main/kotlin/gui/dashboard/Dashboard.kt
+++ b/src/main/kotlin/gui/dashboard/Dashboard.kt
@@ -23,7 +23,7 @@ fun Dashboard(
 @Composable
 private fun Background() {
     Box(
-        Modifier
+        modifier = Modifier
             .fillMaxSize()
             .background(MaterialTheme.colors.background)
     )
@@ -33,10 +33,7 @@ private fun Background() {
 private fun MainRow(viewModel: DashboardViewModel) {
     Row(
         horizontalArrangement = Arrangement.spacedBy(16.dp),
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(intrinsicSize = IntrinsicSize.Max)
-            .padding(16.dp)
+        modifier = Modifier.padding(16.dp)
     ) {
 
         LightOrganTile(
@@ -45,12 +42,12 @@ private fun MainRow(viewModel: DashboardViewModel) {
 
         ColorTile(
             viewModel = viewModel.colorTileViewModel,
-            modifier = Modifier.weight(1f).fillMaxHeight()
+            modifier = Modifier.weight(1f).fillMaxSize()
         )
 
         SpectrumTile(
             viewModel = viewModel.spectrumTileViewModel,
-            modifier = Modifier.weight(1f).fillMaxHeight()
+            modifier = Modifier.weight(1f).fillMaxSize()
         )
 
     }

--- a/src/main/kotlin/gui/dashboard/Dashboard.kt
+++ b/src/main/kotlin/gui/dashboard/Dashboard.kt
@@ -1,5 +1,6 @@
 package gui.dashboard
 
+import SpectrumTile
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
@@ -39,12 +40,16 @@ private fun MainRow(viewModel: DashboardViewModel) {
     ) {
 
         LightOrganTile(
-            viewModel = viewModel.lightOrganTileViewModel,
-            modifier = Modifier.weight(1f).fillMaxHeight()
+            viewModel = viewModel.lightOrganTileViewModel
         )
 
         ColorTile(
             viewModel = viewModel.colorTileViewModel,
+            modifier = Modifier.weight(1f).fillMaxHeight()
+        )
+
+        SpectrumTile(
+            viewModel = viewModel.spectrumTileViewModel,
             modifier = Modifier.weight(1f).fillMaxHeight()
         )
 

--- a/src/main/kotlin/gui/dashboard/DashboardViewModel.kt
+++ b/src/main/kotlin/gui/dashboard/DashboardViewModel.kt
@@ -1,5 +1,6 @@
 package gui.dashboard
 
+import SpectrumTileViewModel
 import config.Config
 import config.ConfigPersister
 import config.ConfigSingleton
@@ -9,6 +10,7 @@ import gui.dashboard.tiles.lightOrgan.LightOrganTileViewModel
 class DashboardViewModel(
     val lightOrganTileViewModel: LightOrganTileViewModel,
     val colorTileViewModel: ColorTileViewModel,
+    val spectrumTileViewModel: SpectrumTileViewModel,
     private val configPersister: ConfigPersister = ConfigPersister(),
     private val config: Config = ConfigSingleton
 ) {

--- a/src/main/kotlin/gui/dashboard/DashboardViewModel.kt
+++ b/src/main/kotlin/gui/dashboard/DashboardViewModel.kt
@@ -1,11 +1,11 @@
 package gui.dashboard
 
-import SpectrumTileViewModel
 import config.Config
 import config.ConfigPersister
 import config.ConfigSingleton
 import gui.dashboard.tiles.color.ColorTileViewModel
 import gui.dashboard.tiles.lightOrgan.LightOrganTileViewModel
+import gui.dashboard.tiles.spectrum.SpectrumTileViewModel
 
 class DashboardViewModel(
     val lightOrganTileViewModel: LightOrganTileViewModel,

--- a/src/main/kotlin/gui/dashboard/DashboardViewModelFactory.kt
+++ b/src/main/kotlin/gui/dashboard/DashboardViewModelFactory.kt
@@ -1,8 +1,8 @@
 package gui.dashboard
 
-import SpectrumTileViewModel
 import gui.dashboard.tiles.color.ColorTileViewModelFactory
 import gui.dashboard.tiles.lightOrgan.LightOrganTileViewModelFactory
+import gui.dashboard.tiles.spectrum.SpectrumTileViewModel
 import lightOrgan.LightOrganStateMachine
 
 val spectrumTileViewModel = SpectrumTileViewModel()

--- a/src/main/kotlin/gui/dashboard/DashboardViewModelFactory.kt
+++ b/src/main/kotlin/gui/dashboard/DashboardViewModelFactory.kt
@@ -5,11 +5,10 @@ import gui.dashboard.tiles.lightOrgan.LightOrganTileViewModelFactory
 import gui.dashboard.tiles.spectrum.SpectrumTileViewModel
 import lightOrgan.LightOrganStateMachine
 
-val spectrumTileViewModel = SpectrumTileViewModel()
-
 class DashboardViewModelFactory(
     private val lightOrganTileViewModelFactory: LightOrganTileViewModelFactory = LightOrganTileViewModelFactory(),
-    private val colorTileViewModelFactory: ColorTileViewModelFactory = ColorTileViewModelFactory()
+    private val colorTileViewModelFactory: ColorTileViewModelFactory = ColorTileViewModelFactory(),
+    private val spectrumTileViewModel: SpectrumTileViewModel = SpectrumTileViewModel()
 ) {
 
     fun create(lightOrganStateMachine: LightOrganStateMachine): DashboardViewModel {

--- a/src/main/kotlin/gui/dashboard/DashboardViewModelFactory.kt
+++ b/src/main/kotlin/gui/dashboard/DashboardViewModelFactory.kt
@@ -1,8 +1,11 @@
 package gui.dashboard
 
+import SpectrumTileViewModel
 import gui.dashboard.tiles.color.ColorTileViewModelFactory
 import gui.dashboard.tiles.lightOrgan.LightOrganTileViewModelFactory
 import lightOrgan.LightOrganStateMachine
+
+val spectrumTileViewModel = SpectrumTileViewModel()
 
 class DashboardViewModelFactory(
     private val lightOrganTileViewModelFactory: LightOrganTileViewModelFactory = LightOrganTileViewModelFactory(),
@@ -12,7 +15,8 @@ class DashboardViewModelFactory(
     fun create(lightOrganStateMachine: LightOrganStateMachine): DashboardViewModel {
         return DashboardViewModel(
             lightOrganTileViewModel = lightOrganTileViewModelFactory.create(lightOrganStateMachine),
-            colorTileViewModel = colorTileViewModelFactory.create()
+            colorTileViewModel = colorTileViewModelFactory.create(),
+            spectrumTileViewModel = spectrumTileViewModel
         )
     }
 

--- a/src/main/kotlin/gui/dashboard/tiles/spectrum/Spectrum.kt
+++ b/src/main/kotlin/gui/dashboard/tiles/spectrum/Spectrum.kt
@@ -1,0 +1,3 @@
+package gui.dashboard.tiles.spectrum
+
+typealias Spectrum = List<SpectrumBin>

--- a/src/main/kotlin/gui/dashboard/tiles/spectrum/SpectrumBin.kt
+++ b/src/main/kotlin/gui/dashboard/tiles/spectrum/SpectrumBin.kt
@@ -1,0 +1,3 @@
+package gui.dashboard.tiles.spectrum
+
+data class SpectrumBin(val frequency: Float, val magnitude: Float, val hovered: Boolean)

--- a/src/main/kotlin/gui/dashboard/tiles/spectrum/SpectrumCreator.kt
+++ b/src/main/kotlin/gui/dashboard/tiles/spectrum/SpectrumCreator.kt
@@ -1,0 +1,17 @@
+package gui.dashboard.tiles.spectrum
+
+import sound.bins.frequency.FrequencyBins
+
+class SpectrumCreator {
+
+    fun create(frequencyBins: FrequencyBins, hoveredFrequency: Float?): List<SpectrumBin> {
+        return frequencyBins.map {
+            SpectrumBin(
+                frequency = it.frequency,
+                magnitude = it.magnitude.coerceIn(0F, 1F),
+                hovered = it.frequency == hoveredFrequency
+            )
+        }
+    }
+
+}

--- a/src/main/kotlin/gui/dashboard/tiles/spectrum/SpectrumTile.kt
+++ b/src/main/kotlin/gui/dashboard/tiles/spectrum/SpectrumTile.kt
@@ -105,7 +105,9 @@ private fun BinColumn(
             }
         }
 
-        HighlightBox(isHighlighted = bin.hovered)
+        if (bin.hovered) {
+            HighlightBox()
+        }
     }
 }
 
@@ -137,12 +139,10 @@ private fun ColoredBox(modifier: Modifier) {
 }
 
 @Composable
-private fun HighlightBox(isHighlighted: Boolean) {
-    if (isHighlighted) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(Color.White.copy(alpha = 0.5f))
-        )
-    }
+private fun HighlightBox() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.White.copy(alpha = 0.5f))
+    )
 }

--- a/src/main/kotlin/gui/dashboard/tiles/spectrum/SpectrumTile.kt
+++ b/src/main/kotlin/gui/dashboard/tiles/spectrum/SpectrumTile.kt
@@ -3,13 +3,19 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.PointerEventType
+import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
 import gui.basicComponents.Grid
 import gui.basicComponents.SimpleSpacer
 import gui.basicComponents.SimpleText
 import gui.basicComponents.Tile
-import sound.bins.frequency.FrequencyBins
+import gui.dashboard.tiles.spectrum.SpectrumBin
+import gui.dashboard.tiles.spectrum.SpectrumTileViewModel
 
 @Preview
 @Composable
@@ -18,16 +24,16 @@ fun SpectrumTile(
     modifier: Modifier = Modifier
 ) {
     Tile(modifier) {
-        title()
+        Title()
         SimpleSpacer(dpSize = 12)
-        Grid {
-            chart(viewModel.frequencyBins.value)
-        }
+        HoveredDetails(frequency = viewModel.hoveredFrequency)
+        SimpleSpacer(dpSize = 12)
+        GridSpectrum(viewModel)
     }
 }
 
 @Composable
-private fun title() {
+private fun Title() {
     SimpleText(
         text = "Spectrum",
         fontSize = 24,
@@ -36,24 +42,107 @@ private fun title() {
 }
 
 @Composable
-private fun chart(frequencyBins: FrequencyBins) {
-    Row {
-        frequencyBins.forEach { frequencyBin ->
-            Column(
-                Modifier
-                    .fillMaxHeight()
-                    .weight(1f)
-            ) {
-                val magnitude = frequencyBin.magnitude.coerceIn(0.01f, 0.99f)
-                Spacer(modifier = Modifier.weight(1f - magnitude))
-                Box(
-                    Modifier
-                        .fillMaxWidth()
-                        .weight(magnitude)
-                        .background(MaterialTheme.colors.secondary)
+private fun HoveredDetails(frequency: String?) {
+    SimpleText(
+        text = "Frequency: $frequency",
+        fontSize = 16
+    )
+}
+
+@Composable
+private fun GridSpectrum(viewModel: SpectrumTileViewModel) {
+    Grid {
+        Spectrum(viewModel)
+    }
+}
+
+@Composable
+private fun Spectrum(viewModel: SpectrumTileViewModel) {
+    val bins = viewModel.spectrum
+
+    // NOTE: The spectrum will distort if we are not explicit about widths because not all columns will scale at the same time.
+    // We set most of the widths explicitly, but leave the final column to fill the remaining space.
+    BoxWithConstraints {
+        val columnWidth = maxWidth / bins.size
+
+        Row {
+            bins.forEach { bin ->
+                BinColumn(
+                    bin = bin,
+                    viewModel = viewModel,
+                    modifier = getBinColumnModifier(bin, bins, columnWidth)
                 )
             }
-//            Spacer(modifier = Modifier.width(1.dp))
         }
+    }
+}
+
+private fun getBinColumnModifier(bin: SpectrumBin, bins: List<SpectrumBin>, columnWidth: Dp): Modifier {
+    return if (bin != bins.last()) {
+        Modifier.width(columnWidth)
+    } else {
+        Modifier.fillMaxWidth()
+    }
+}
+
+@Composable
+private fun BinColumn(
+    bin: SpectrumBin,
+    viewModel: SpectrumTileViewModel,
+    modifier: Modifier
+) {
+    Box(modifier = modifier.onHoverChanged(viewModel, bin)) {
+        Column {
+            val clearWeight = 1F - bin.magnitude
+            val coloredWeight = bin.magnitude
+
+            if (clearWeight > 0F) {
+                ClearBox(modifier = Modifier.weight(clearWeight))
+            }
+
+            if (coloredWeight > 0F) {
+                ColoredBox(modifier = Modifier.weight(coloredWeight))
+            }
+        }
+
+        HighlightBox(isHighlighted = bin.hovered)
+    }
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+private fun Modifier.onHoverChanged(viewModel: SpectrumTileViewModel, bin: SpectrumBin): Modifier {
+    return this.onPointerEvent(PointerEventType.Enter) {
+        viewModel.setHoveredBin(bin)
+    }.onPointerEvent(PointerEventType.Exit) {
+        viewModel.setHoveredBin(null)
+    }
+}
+
+@Composable
+private fun ClearBox(modifier: Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.Transparent)
+    )
+}
+
+@Composable
+private fun ColoredBox(modifier: Modifier) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colors.secondary)
+    )
+}
+
+@Composable
+private fun HighlightBox(isHighlighted: Boolean) {
+    if (isHighlighted) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.White.copy(alpha = 0.5f))
+        )
     }
 }

--- a/src/main/kotlin/gui/dashboard/tiles/spectrum/SpectrumTile.kt
+++ b/src/main/kotlin/gui/dashboard/tiles/spectrum/SpectrumTile.kt
@@ -1,10 +1,8 @@
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -77,18 +75,7 @@ private fun BinColumn(
     modifier: Modifier
 ) {
     Box(modifier = modifier.onHoverChanged(viewModel, bin)) {
-        Column {
-            val clearWeight = 1F - bin.magnitude
-            val coloredWeight = bin.magnitude
-
-            if (clearWeight > 0F) {
-                ClearBox(modifier = Modifier.weight(clearWeight))
-            }
-
-            if (coloredWeight > 0F) {
-                ColoredBox(modifier = Modifier.weight(coloredWeight))
-            }
-        }
+        Bar(value = bin.magnitude)
 
         if (bin.hovered) {
             HighlightBox()
@@ -103,24 +90,6 @@ private fun Modifier.onHoverChanged(viewModel: SpectrumTileViewModel, bin: Spect
     }.onPointerEvent(PointerEventType.Exit) {
         viewModel.setHoveredBin(null)
     }
-}
-
-@Composable
-private fun ClearBox(modifier: Modifier) {
-    Box(
-        modifier = modifier
-            .fillMaxSize()
-            .background(Color.Transparent)
-    )
-}
-
-@Composable
-private fun ColoredBox(modifier: Modifier) {
-    Box(
-        modifier = modifier
-            .fillMaxSize()
-            .background(MaterialTheme.colors.secondary)
-    )
 }
 
 @Composable

--- a/src/main/kotlin/gui/dashboard/tiles/spectrum/SpectrumTile.kt
+++ b/src/main/kotlin/gui/dashboard/tiles/spectrum/SpectrumTile.kt
@@ -2,7 +2,6 @@ import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
@@ -60,8 +59,7 @@ private fun Spectrum(viewModel: SpectrumTileViewModel) {
             {
                 BinColumn(
                     bin = bin,
-                    viewModel = viewModel,
-                    modifier = Modifier.fillMaxWidth()
+                    viewModel = viewModel
                 )
             }
         }
@@ -71,10 +69,9 @@ private fun Spectrum(viewModel: SpectrumTileViewModel) {
 @Composable
 private fun BinColumn(
     bin: SpectrumBin,
-    viewModel: SpectrumTileViewModel,
-    modifier: Modifier
+    viewModel: SpectrumTileViewModel
 ) {
-    Box(modifier = modifier.onHoverChanged(viewModel, bin)) {
+    Box(modifier = Modifier.onHoverChanged(viewModel, bin)) {
         Bar(value = bin.magnitude)
 
         if (bin.hovered) {

--- a/src/main/kotlin/gui/dashboard/tiles/spectrum/SpectrumTile.kt
+++ b/src/main/kotlin/gui/dashboard/tiles/spectrum/SpectrumTile.kt
@@ -1,6 +1,9 @@
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -9,11 +12,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.PointerEventType
 import androidx.compose.ui.input.pointer.onPointerEvent
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.Dp
-import gui.basicComponents.Grid
-import gui.basicComponents.SimpleSpacer
-import gui.basicComponents.SimpleText
-import gui.basicComponents.Tile
+import gui.basicComponents.*
 import gui.dashboard.tiles.spectrum.SpectrumBin
 import gui.dashboard.tiles.spectrum.SpectrumTileViewModel
 
@@ -58,31 +57,17 @@ private fun GridSpectrum(viewModel: SpectrumTileViewModel) {
 
 @Composable
 private fun Spectrum(viewModel: SpectrumTileViewModel) {
-    val bins = viewModel.spectrum
-
-    // NOTE: The spectrum will distort if we are not explicit about widths because not all columns will scale at the same time.
-    // We set most of the widths explicitly, but leave the final column to fill the remaining space.
-    BoxWithConstraints {
-        val columnWidth = maxWidth / bins.size
-
-        Row {
-            bins.forEach { bin ->
+    RowWithEqualColumnWidths(
+        children = viewModel.spectrum.map { bin ->
+            {
                 BinColumn(
                     bin = bin,
                     viewModel = viewModel,
-                    modifier = getBinColumnModifier(bin, bins, columnWidth)
+                    modifier = Modifier.fillMaxWidth()
                 )
             }
         }
-    }
-}
-
-private fun getBinColumnModifier(bin: SpectrumBin, bins: List<SpectrumBin>, columnWidth: Dp): Modifier {
-    return if (bin != bins.last()) {
-        Modifier.width(columnWidth)
-    } else {
-        Modifier.fillMaxWidth()
-    }
+    )
 }
 
 @Composable

--- a/src/main/kotlin/gui/dashboard/tiles/spectrum/SpectrumTile.kt
+++ b/src/main/kotlin/gui/dashboard/tiles/spectrum/SpectrumTile.kt
@@ -1,0 +1,59 @@
+import androidx.compose.desktop.ui.tooling.preview.Preview
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import gui.basicComponents.Grid
+import gui.basicComponents.SimpleSpacer
+import gui.basicComponents.SimpleText
+import gui.basicComponents.Tile
+import sound.bins.frequency.FrequencyBins
+
+@Preview
+@Composable
+fun SpectrumTile(
+    viewModel: SpectrumTileViewModel,
+    modifier: Modifier = Modifier
+) {
+    Tile(modifier) {
+        title()
+        SimpleSpacer(dpSize = 12)
+        Grid {
+            chart(viewModel.frequencyBins.value)
+        }
+    }
+}
+
+@Composable
+private fun title() {
+    SimpleText(
+        text = "Spectrum",
+        fontSize = 24,
+        fontWeight = FontWeight.SemiBold
+    )
+}
+
+@Composable
+private fun chart(frequencyBins: FrequencyBins) {
+    Row {
+        frequencyBins.forEach { frequencyBin ->
+            Column(
+                Modifier
+                    .fillMaxHeight()
+                    .weight(1f)
+            ) {
+                val magnitude = frequencyBin.magnitude.coerceIn(0.01f, 0.99f)
+                Spacer(modifier = Modifier.weight(1f - magnitude))
+                Box(
+                    Modifier
+                        .fillMaxWidth()
+                        .weight(magnitude)
+                        .background(MaterialTheme.colors.secondary)
+                )
+            }
+//            Spacer(modifier = Modifier.width(1.dp))
+        }
+    }
+}

--- a/src/main/kotlin/gui/dashboard/tiles/spectrum/SpectrumTileViewModel.kt
+++ b/src/main/kotlin/gui/dashboard/tiles/spectrum/SpectrumTileViewModel.kt
@@ -32,8 +32,8 @@ class SpectrumTileViewModel(
 
     fun setHoveredBin(hoveredBin: SpectrumBin?) {
         this.hoveredBin = hoveredBin
-        updateHoveredFrequency()
         updateSpectrum()
+        updateHoveredFrequency()
     }
 
     private fun updateHoveredFrequency() {

--- a/src/main/kotlin/gui/dashboard/tiles/spectrum/SpectrumTileViewModel.kt
+++ b/src/main/kotlin/gui/dashboard/tiles/spectrum/SpectrumTileViewModel.kt
@@ -1,15 +1,54 @@
-import androidx.compose.runtime.MutableState
+package gui.dashboard.tiles.spectrum
+
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.launch
+import androidx.compose.runtime.setValue
 import sound.bins.frequency.FrequencyBins
+import java.util.*
 
-class SpectrumTileViewModel {
-    val frequencyBins: MutableState<FrequencyBins> = mutableStateOf(listOf())
+class SpectrumTileViewModel(
+    private val spectrumCreator: SpectrumCreator = SpectrumCreator()
+) {
 
-    fun updateFrequencyBins(newFrequencyBins: FrequencyBins) {
-        MainScope().launch {
-            frequencyBins.value = newFrequencyBins
+    private var frequencyBins: FrequencyBins = listOf()
+    private var hoveredBin: SpectrumBin? = null
+
+    var spectrum by mutableStateOf<Spectrum>(listOf())
+        private set
+    var hoveredFrequency by mutableStateOf("")
+        private set
+
+    fun setFrequencyBins(frequencyBins: FrequencyBins) {
+        this.frequencyBins = frequencyBins
+        updateSpectrum()
+    }
+
+    private fun updateSpectrum() {
+        spectrum = spectrumCreator.create(
+            frequencyBins = frequencyBins,
+            hoveredFrequency = hoveredBin?.frequency
+        )
+    }
+
+    fun setHoveredBin(hoveredBin: SpectrumBin?) {
+        this.hoveredBin = hoveredBin
+        updateHoveredFrequency()
+        updateSpectrum()
+    }
+
+    private fun updateHoveredFrequency() {
+        val frequency = hoveredBin?.frequency
+
+        if (frequency != null) {
+            val formattedFrequency = frequency.formatToTwoDecimalPoints()
+            hoveredFrequency = "$formattedFrequency Hz"
+        } else {
+            hoveredFrequency = ""
         }
     }
+
+    private fun Float.formatToTwoDecimalPoints(): String {
+        return String.format(Locale.US, "%.2f", this)
+    }
+
 }

--- a/src/main/kotlin/gui/dashboard/tiles/spectrum/SpectrumTileViewModel.kt
+++ b/src/main/kotlin/gui/dashboard/tiles/spectrum/SpectrumTileViewModel.kt
@@ -1,0 +1,15 @@
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
+import sound.bins.frequency.FrequencyBins
+
+class SpectrumTileViewModel {
+    val frequencyBins: MutableState<FrequencyBins> = mutableStateOf(listOf())
+
+    fun updateFrequencyBins(newFrequencyBins: FrequencyBins) {
+        MainScope().launch {
+            frequencyBins.value = newFrequencyBins
+        }
+    }
+}

--- a/src/main/kotlin/gui/dashboard/tiles/spectrum/SpectrumTileViewModel.kt
+++ b/src/main/kotlin/gui/dashboard/tiles/spectrum/SpectrumTileViewModel.kt
@@ -3,8 +3,11 @@ package gui.dashboard.tiles.spectrum
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import org.greenrobot.eventbus.EventBus
+import org.greenrobot.eventbus.Subscribe
 import sound.bins.frequency.FrequencyBins
 import java.util.*
+
 
 class SpectrumTileViewModel(
     private val spectrumCreator: SpectrumCreator = SpectrumCreator()
@@ -18,6 +21,12 @@ class SpectrumTileViewModel(
     var hoveredFrequency by mutableStateOf("")
         private set
 
+
+    init {
+        EventBus.getDefault().register(this)
+    }
+
+    @Subscribe
     fun setFrequencyBins(frequencyBins: FrequencyBins) {
         this.frequencyBins = frequencyBins
         updateSpectrum()

--- a/src/test/kotlin/gui/dashboard/DashboardViewModelTests.kt
+++ b/src/test/kotlin/gui/dashboard/DashboardViewModelTests.kt
@@ -4,6 +4,7 @@ import config.Config
 import config.ConfigPersister
 import gui.dashboard.tiles.color.ColorTileViewModel
 import gui.dashboard.tiles.lightOrgan.LightOrganTileViewModel
+import gui.dashboard.tiles.spectrum.SpectrumTileViewModel
 import io.mockk.clearAllMocks
 import io.mockk.mockk
 import io.mockk.verify
@@ -14,6 +15,7 @@ class DashboardViewModelTests {
 
     private val lightOrganTileViewModel: LightOrganTileViewModel = mockk(relaxed = true)
     private val colorTileViewModel: ColorTileViewModel = mockk(relaxed = true)
+    private val spectrumTileViewModel: SpectrumTileViewModel = mockk(relaxed = true)
     private val configPersister: ConfigPersister = mockk(relaxed = true)
     private val config: Config = mockk(relaxed = true)
 
@@ -27,6 +29,7 @@ class DashboardViewModelTests {
             lightOrganTileViewModel = lightOrganTileViewModel,
             colorTileViewModel = colorTileViewModel,
             configPersister = configPersister,
+            spectrumTileViewModel = spectrumTileViewModel,
             config = config
         )
     }

--- a/src/test/kotlin/gui/dashboard/tiles/spectrum/SpectrumCreatorTests.kt
+++ b/src/test/kotlin/gui/dashboard/tiles/spectrum/SpectrumCreatorTests.kt
@@ -1,0 +1,66 @@
+package gui.dashboard.tiles.spectrum
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import sound.bins.frequency.FrequencyBin
+
+class SpectrumCreatorTests {
+
+    private val frequencyBin10 = FrequencyBin(10F, 0.0F)
+    private val frequencyBin20 = FrequencyBin(20F, 0.5F)
+    private val frequencyBin30 = FrequencyBin(30F, 1.0F)
+
+    private fun createSUT(): SpectrumCreator {
+        return SpectrumCreator()
+    }
+
+    @Test
+    fun `create a frequency spectrum`() {
+        val sut = createSUT()
+        val frequencyBins = listOf(frequencyBin10, frequencyBin20, frequencyBin30)
+
+        val spectrum = sut.create(frequencyBins, null)
+
+        assertEquals(
+            listOf(
+                SpectrumBin(10F, 0.0F, false),
+                SpectrumBin(20F, 0.5F, false),
+                SpectrumBin(30F, 1.0F, false)
+            ), spectrum
+        )
+    }
+
+    @Test
+    fun `the bin matching the hovered frequency is hovered`() {
+        val sut = createSUT()
+        val frequencyBins = listOf(frequencyBin10, frequencyBin20, frequencyBin30)
+
+        val spectrum = sut.create(frequencyBins, hoveredFrequency = 20F)
+
+        assertEquals(
+            listOf(
+                SpectrumBin(10F, 0.0F, false),
+                SpectrumBin(20F, 0.5F, true),
+                SpectrumBin(30F, 1.0F, false)
+            ), spectrum
+        )
+    }
+
+    @Test
+    fun `magnitudes have a range of 0 to 1`() {
+        val sut = createSUT()
+        val lowFrequencyBin = FrequencyBin(10F, -2F)
+        val highFrequencyBin = FrequencyBin(20F, 2F)
+        val frequencyBins = listOf(lowFrequencyBin, highFrequencyBin)
+
+        val spectrum = sut.create(frequencyBins, null)
+
+        assertEquals(
+            listOf(
+                SpectrumBin(10F, 0F, false),
+                SpectrumBin(20F, 1F, false)
+            ), spectrum
+        )
+    }
+
+}

--- a/src/test/kotlin/gui/dashboard/tiles/spectrum/SpectrumTileViewModelTests.kt
+++ b/src/test/kotlin/gui/dashboard/tiles/spectrum/SpectrumTileViewModelTests.kt
@@ -1,0 +1,79 @@
+package gui.dashboard.tiles.spectrum
+
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import toolkit.monkeyTest.nextFrequencyBins
+import toolkit.monkeyTest.nextSpectrum
+import toolkit.monkeyTest.nextSpectrumBin
+
+class SpectrumTileViewModelTests {
+
+    private val spectrumCreator: SpectrumCreator = mockk()
+    private val spectrum = nextSpectrum()
+
+    @BeforeEach
+    fun setupHappyPath() {
+        every { spectrumCreator.create(any(), any()) } returns spectrum
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    private fun createSUT(): SpectrumTileViewModel {
+        return SpectrumTileViewModel(
+            spectrumCreator = spectrumCreator
+        )
+    }
+
+    @Test
+    fun `settings new frequency bins updates the spectrum`() {
+        val sut = createSUT()
+        val frequencyBins = nextFrequencyBins()
+
+        sut.setFrequencyBins(frequencyBins)
+
+        verify { spectrumCreator.create(frequencyBins, null) }
+        assertEquals(spectrum, sut.spectrum)
+    }
+
+    @Test
+    fun `setting a hovered bin updates the spectrum`() {
+        val sut = createSUT()
+        val hoveredBin = nextSpectrumBin()
+
+        sut.setHoveredBin(hoveredBin)
+
+        verify { spectrumCreator.create(listOf(), hoveredBin.frequency) }
+        assertEquals(spectrum, sut.spectrum)
+    }
+
+    @Test
+    fun `setting a hovered bin updates the hovered frequency`() {
+        val sut = createSUT()
+        val hoveredBin = SpectrumBin(20.123F, 1F, false)
+
+        sut.setHoveredBin(hoveredBin)
+
+        assertEquals("20.12 Hz", sut.hoveredFrequency)
+    }
+
+    @Test
+    fun `clearing the hovered bin clears the hovered frequency`() {
+        val sut = createSUT()
+        sut.setHoveredBin(nextSpectrumBin())
+
+        sut.setHoveredBin(null)
+
+        assertEquals("", sut.hoveredFrequency)
+    }
+
+}
+

--- a/src/test/kotlin/toolkit/monkeyTest/NextSpectrum.kt
+++ b/src/test/kotlin/toolkit/monkeyTest/NextSpectrum.kt
@@ -1,0 +1,18 @@
+package toolkit.monkeyTest
+
+import gui.dashboard.tiles.spectrum.Spectrum
+import gui.dashboard.tiles.spectrum.SpectrumBin
+import kotlin.random.Random
+
+fun nextSpectrum(
+    length: Int = Random.nextInt(1, 10)
+): Spectrum {
+    val list: MutableList<SpectrumBin> = mutableListOf()
+
+    repeat(length) {
+        list.add(nextSpectrumBin())
+    }
+
+    return list.toList()
+}
+

--- a/src/test/kotlin/toolkit/monkeyTest/NextSpectrumBin.kt
+++ b/src/test/kotlin/toolkit/monkeyTest/NextSpectrumBin.kt
@@ -1,0 +1,15 @@
+package toolkit.monkeyTest
+
+import gui.dashboard.tiles.spectrum.SpectrumBin
+import kotlin.random.Random
+
+fun nextSpectrumBin(
+    frequency: Float = Random.nextFloat(),
+    magnitude: Float = Random.nextFloat()
+): SpectrumBin {
+    return SpectrumBin(
+        frequency = frequency,
+        magnitude = magnitude,
+        hovered = Random.nextBoolean()
+    )
+}

--- a/src/test/kotlin/toolkit/monkeyTest/NextSpectrumBin.kt
+++ b/src/test/kotlin/toolkit/monkeyTest/NextSpectrumBin.kt
@@ -3,13 +3,10 @@ package toolkit.monkeyTest
 import gui.dashboard.tiles.spectrum.SpectrumBin
 import kotlin.random.Random
 
-fun nextSpectrumBin(
-    frequency: Float = Random.nextFloat(),
-    magnitude: Float = Random.nextFloat()
-): SpectrumBin {
+fun nextSpectrumBin(): SpectrumBin {
     return SpectrumBin(
-        frequency = frequency,
-        magnitude = magnitude,
+        frequency = Random.nextFloat(),
+        magnitude = Random.nextFloat(),
         hovered = Random.nextBoolean()
     )
 }


### PR DESCRIPTION
I have created a spectrum tile for debugging purposes. It illustrates the frequency bins that are being used for processing. It is a bit ugly, but I think it is better to represent the raw data instead making it prettier.

It is computationally expensive, so there could be value in adding a button to turn it off. I am also updating the spectrum whenever the hovered bin changes, which is also wasteful. These should be considered as possible optimization for future PRs.

I have omitted tests pertaining to the Event Bus as I plan to replace it with a dependency injection tool. Of course, temporary things have a tendency of becoming permanent - but this is a case where the _design deficiency_ (pain of passing around dependencies) is known and there is low risk of something breaking (as it is very obvious if the spectrum stops working).