### PR TITLE
Updating the API for the rolling buffers

### DIFF
--- a/src/main/kotlin/audio/samples/RollingAudioBuffer.kt
+++ b/src/main/kotlin/audio/samples/RollingAudioBuffer.kt
@@ -1,26 +1,33 @@
 package audio.samples
 
 class RollingAudioBuffer(
-    private val capacity: Int
+    private val rollingSampleBuffer: RollingSampleBuffer = RollingSampleBuffer()
 ) {
 
     private var format: AudioFormat? = null
-    private val rollingSampleBuffer: RollingSampleBuffer = RollingSampleBuffer(capacity)
+
+    var size: Int
+        get() = rollingSampleBuffer.size
+        set(value) {
+            rollingSampleBuffer.size = value
+        }
+
+    val current: AudioFrame?
+        get() {
+            val format = format ?: return null
+            return AudioFrame(rollingSampleBuffer.current, format)
+        }
 
     fun append(frame: AudioFrame): AudioFrame {
         if (frame.format != format) {
-            reset()
+            format = frame.format
+            rollingSampleBuffer.reset()
         }
 
-        format = frame.format
-        rollingSampleBuffer.append(frame.samples)
-
-        return AudioFrame(rollingSampleBuffer.current, frame.format)
-    }
-
-    private fun reset() {
-        format = null
-        rollingSampleBuffer.reset()
+        return AudioFrame(
+            samples = rollingSampleBuffer.append(frame.samples),
+            format = frame.format
+        )
     }
 
 }

--- a/src/main/kotlin/audio/samples/RollingSampleBuffer.kt
+++ b/src/main/kotlin/audio/samples/RollingSampleBuffer.kt
@@ -3,30 +3,39 @@ package audio.samples
 import extensions.takeLastArray
 import logging.Logger
 
-class RollingSampleBuffer(size: Int) {
+class RollingSampleBuffer(initialSize: Int = 0) {
 
-    private val samples = FloatArray(size)
+    private var samples = FloatArray(initialSize)
 
     val current: FloatArray
         get() = samples.copyOf()
 
-    fun append(newSamples: FloatArray) {
+    var size: Int = samples.size
+        set(value) {
+            if (field == value) return
+            field = value
+            resize(value)
+        }
+
+    private fun resize(newSize: Int) {
+        val old = samples
+        samples = FloatArray(newSize)
+        val copyCount = minOf(old.size, newSize)
+        old.copyInto(samples, destinationOffset = newSize - copyCount, startIndex = old.size - copyCount)
+    }
+
+    fun append(newSamples: FloatArray): FloatArray {
         checkForDiscontinuity(newSamples)
 
-        // Trim our new samples to prevent buffer overflow
         val trimmed = newSamples.takeLastArray(samples.size)
-
-        // Shift existing samples over (i.e., back in time)
         samples.copyInto(samples, destinationOffset = 0, startIndex = trimmed.size)
-
-        // Copy new samples into the end of the buffer (i.e., the most recent time)
         trimmed.copyInto(samples, destinationOffset = samples.size - trimmed.size)
+
+        return current
     }
 
     private fun checkForDiscontinuity(newSamples: FloatArray) {
-        val causesDiscontinuity = newSamples.size > samples.size
-
-        if (causesDiscontinuity) {
+        if (newSamples.size > samples.size) {
             Logger.warning("Rolling buffer has dropped samples. (${newSamples.size} new samples, buffer capacity ${samples.size})")
         }
     }

--- a/src/main/kotlin/lightOrgan/spectrum/SpectrumManager.kt
+++ b/src/main/kotlin/lightOrgan/spectrum/SpectrumManager.kt
@@ -21,11 +21,15 @@ class SpectrumManager(
     private val config: SpectrumConfig = ConfigSingleton.spectrum,
     private val monoMixer: MonoMixer = MonoMixer(),
     private val filterBuilder: FilterBuilder = FilterBuilder(),
-    private val audioBuffer: RollingAudioBuffer = RollingAudioBuffer(config.sampleSize),
+    private val audioBuffer: RollingAudioBuffer = RollingAudioBuffer(),
     private val window: Window = config.window.createWindow(),
     private val interpolator: ZeroPaddingInterpolator = ZeroPaddingInterpolator(),
     private val frequencyBinsCalculator: FrequencyBinsCalculator = FrequencyBinsCalculator()
 ) {
+
+    init {
+        audioBuffer.size = config.sampleSize
+    }
 
     private var highPassFilter: OrderedFilter? = null
     private var lowPassFilter: OrderedFilter? = null

--- a/src/test/kotlin/audio/samples/RollingAudioBufferTests.kt
+++ b/src/test/kotlin/audio/samples/RollingAudioBufferTests.kt
@@ -1,76 +1,129 @@
 package audio.samples
 
+import io.mockk.*
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNull
 import toolkit.monkeyTest.nextAudioFormat
+import toolkit.monkeyTest.nextAudioFrame
+import toolkit.monkeyTest.nextFloatArray
 import toolkit.monkeyTest.nextPositiveInt
 
 class RollingAudioBufferTests {
 
-    private val randomSize = nextPositiveInt()
+    private val rollingSampleBuffer: RollingSampleBuffer = mockk()
+
     private val format1 = nextAudioFormat()
     private val format2 = nextAudioFormat()
+    private val format1Frame1 = nextAudioFrame(format = format1)
+    private val format1Frame2 = nextAudioFrame(format = format1)
+    private val format2Frame = nextAudioFrame(format = format2)
 
-    private val format1Frame1 = AudioFrame(samples = floatArrayOf(1f, 2f), format1)
-    private val format1Frame2 = AudioFrame(samples = floatArrayOf(3f, 4f), format1)
-    private val format2Frame1 = AudioFrame(samples = floatArrayOf(5f, 6f), format2)
+    private val bufferSize = nextPositiveInt()
+    private val bufferedSamples = nextFloatArray()
 
+    @BeforeEach
+    fun setupHappyPath() {
+        every { rollingSampleBuffer.size = any() } just runs
+        every { rollingSampleBuffer.size } returns bufferSize
+        every { rollingSampleBuffer.current } returns bufferedSamples
+        every { rollingSampleBuffer.append(any()) } returns bufferedSamples
+        every { rollingSampleBuffer.reset() } returns Unit
+    }
+
+    @AfterEach
+    fun teardown() {
+        clearAllMocks()
+    }
+
+    private fun createSUT(): RollingAudioBuffer {
+        return RollingAudioBuffer(rollingSampleBuffer)
+    }
+
+    // Current
     @Test
-    fun `appending frame smaller than capacity is padded with leading zeros`() {
-        val sut = RollingAudioBuffer(capacity = 4)
+    fun `given no audio has been appended, then current is null`() {
+        val sut = createSUT()
 
-        val frame = AudioFrame(floatArrayOf(1f, 2f), format1)
-        val actual = sut.append(frame)
-
-        assertArrayEquals(floatArrayOf(0f, 0f, 1f, 2f), actual.samples)
+        assertNull(sut.current)
     }
 
     @Test
-    fun `appending frame equal to capacity fills the buffer exactly`() {
-        val sut = RollingAudioBuffer(capacity = 3)
+    fun `given audio has been appended, then get the buffered audio frame`() {
+        val sut = createSUT()
+        sut.append(format1Frame1)
 
-        val frame = AudioFrame(floatArrayOf(1f, 2f, 3f), format1)
-        val actual = sut.append(frame)
+        val result = sut.current
 
-        assertArrayEquals(floatArrayOf(1f, 2f, 3f), actual.samples)
+        assertArrayEquals(bufferedSamples, result?.samples)
+        assertEquals(format1, result?.format)
+    }
+
+    // Appending
+    @Test
+    fun `append samples from an audio frame`() {
+        val sut = createSUT()
+
+        sut.append(format1Frame1)
+
+        verify { rollingSampleBuffer.append(format1Frame1.samples) }
+    }
+
+
+    @Test
+    fun `when appending, return the buffered audio frame`() {
+        val sut = createSUT()
+
+        val result = sut.append(format1Frame1)
+
+        assertArrayEquals(bufferedSamples, result.samples)
+        assertEquals(format1, result.format)
+    }
+
+    // Resetting
+    @Test
+    fun `reset buffer when the audio format changes`() {
+        val sut = createSUT()
+        sut.append(format1Frame1)
+        clearMocks(rollingSampleBuffer, answers = false) // As written, the initial append() also triggers it
+
+        sut.append(format2Frame)
+
+        verify { rollingSampleBuffer.reset() }
     }
 
     @Test
-    fun `appending frame larger than capacity keeps only the final samples`() {
-        val sut = RollingAudioBuffer(capacity = 2)
+    fun `preserves buffer when audio format is unchanged`() {
+        val sut = createSUT()
+        sut.append(format1Frame1)
+        clearMocks(rollingSampleBuffer, answers = false)
 
-        val frame = AudioFrame(floatArrayOf(1f, 2f, 3f, 4f, 5f), format1)
-        val actual = sut.append(frame)
+        sut.append(format1Frame2)
 
-        assertArrayEquals(floatArrayOf(4f, 5f), actual.samples)
+        verify(exactly = 0) { rollingSampleBuffer.reset() }
+    }
+
+    // Size
+    @Test
+    fun `get the buffer size`() {
+        val sut = createSUT()
+
+        val result = sut.size
+
+        assertEquals(bufferSize, result)
     }
 
     @Test
-    fun `appending multiple frames of the same format`() {
-        val sut = RollingAudioBuffer(capacity = 4)
+    fun `set the buffer size`() {
+        val sut = createSUT()
+        val randomSize = nextPositiveInt()
 
-        val actual1 = sut.append(format1Frame1)
-        assertArrayEquals(floatArrayOf(0f, 0f, 1f, 2f), actual1.samples)
-        assertEquals(format1, actual1.format)
+        sut.size = randomSize
 
-
-        val actual2 = sut.append(format1Frame2)
-        assertArrayEquals(floatArrayOf(1f, 2f, 3f, 4f), actual2.samples)
-        assertEquals(format1, actual2.format)
-    }
-
-    @Test
-    fun `appending multiple frames of different forms clears previous samples`() {
-        val sut = RollingAudioBuffer(capacity = 5)
-
-        val actual1 = sut.append(format1Frame1)
-        assertArrayEquals(floatArrayOf(0f, 0f, 0f, 1f, 2f), actual1.samples)
-        assertEquals(format1, actual1.format)
-
-        val actual2 = sut.append(AudioFrame(floatArrayOf(3f, 4f), format2))
-        assertArrayEquals(floatArrayOf(0f, 0f, 0f, 3f, 4f), actual2.samples)
-        assertEquals(format2, actual2.format)
+        verify { rollingSampleBuffer.size = randomSize }
     }
 
 }

--- a/src/test/kotlin/audio/samples/RollingSampleBufferTests.kt
+++ b/src/test/kotlin/audio/samples/RollingSampleBufferTests.kt
@@ -1,50 +1,103 @@
 package audio.samples
 
 import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import toolkit.monkeyTest.nextPositiveInt
 
 class RollingSampleBufferTests {
 
+    private val size = nextPositiveInt()
+
+    // Init
     @Test
     fun `initialize an empty buffer`() {
-        val size = nextPositiveInt()
         val sut = RollingSampleBuffer(size)
 
         val expected = FloatArray(size) { 0f }
         assertArrayEquals(expected, sut.current)
     }
 
+
+    // Append
     @Test
-    fun `protect internal state from being directly modified`() {
-        val sut = RollingSampleBuffer(4)
-        val original = floatArrayOf(1f, 2f, 3f, 4f)
-        sut.append(original)
-
-        val snapshot = sut.current
-        snapshot[0] = 999f
-
-        assertArrayEquals(original, sut.current)
-    }
-
-    @Test
-    fun `appended samples are added to the end of the buffer and the oldest are discarded`() {
+    fun `append adds samples to the end of the buffer`() {
         val sut = RollingSampleBuffer(4)
 
         sut.append(floatArrayOf(1f, 2f))
-        sut.append(floatArrayOf(3f, 4f))
-        sut.append(floatArrayOf(5f, 6f))
 
-        assertArrayEquals(floatArrayOf(3f, 4f, 5f, 6f), sut.current)
+        val expected = floatArrayOf(0f, 0f, 1f, 2f)
+        assertArrayEquals(expected, sut.current)
     }
 
     @Test
-    fun `when appending data longer than the buffer can hold, then keep the latest samples`() {
+    fun `appending more than the capacity keeps the latest samples`() {
         val sut = RollingSampleBuffer(4)
 
         sut.append(floatArrayOf(1f, 2f, 3f, 4f, 5f, 6f))
 
-        assertArrayEquals(floatArrayOf(3f, 4f, 5f, 6f), sut.current)
+        val expected = floatArrayOf(3f, 4f, 5f, 6f)
+        assertArrayEquals(expected, sut.current)
+    }
+
+    @Test
+    fun `append returns the current buffer state`() {
+        val sut = RollingSampleBuffer(4)
+
+        val result = sut.append(floatArrayOf(1f, 2f))
+
+        val expected = floatArrayOf(0f, 0f, 1f, 2f)
+        assertArrayEquals(expected, result)
+    }
+
+    // Size
+    @Test
+    fun `get the buffer size`() {
+        val sut = RollingSampleBuffer(size)
+
+        assertEquals(size, sut.size)
+    }
+
+    @Test
+    fun `set the buffer size`() {
+        val sut = RollingSampleBuffer()
+        val newSize = nextPositiveInt()
+
+        sut.size = newSize
+
+        assertEquals(newSize, sut.size)
+    }
+
+    @Test
+    fun `increasing size preserves existing samples`() {
+        val sut = RollingSampleBuffer(4)
+        sut.append(floatArrayOf(1f, 2f, 3f, 4f))
+
+        sut.size = 6
+
+        assertArrayEquals(floatArrayOf(0f, 0f, 1f, 2f, 3f, 4f), sut.current)
+    }
+
+    @Test
+    fun `decreasing size keeps the most recent samples`() {
+        val sut = RollingSampleBuffer(4)
+        sut.append(floatArrayOf(1f, 2f, 3f, 4f))
+
+        sut.size = 2
+
+        assertArrayEquals(floatArrayOf(3f, 4f), sut.current)
+    }
+
+    // Current
+    @Test
+    fun `current cannot be mutated externally`() {
+        val sut = RollingSampleBuffer(4)
+        sut.append(floatArrayOf(1f, 2f, 3f, 4f))
+
+        val snapshot = sut.current
+        snapshot[0] = 999f
+
+        assertArrayEquals(floatArrayOf(1f, 2f, 3f, 4f), sut.current)
     }
 
 }

--- a/src/test/kotlin/lightOrgan/LightOrganTests.kt
+++ b/src/test/kotlin/lightOrgan/LightOrganTests.kt
@@ -4,7 +4,6 @@ import color.ColorFactory
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.TestScope
@@ -17,6 +16,7 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import server.Server
+import toolkit.assertions.eventually
 import toolkit.monkeyTest.nextAudioFrame
 import toolkit.monkeyTest.nextAudioStreamFrame
 import toolkit.monkeyTest.nextColor
@@ -78,9 +78,9 @@ class LightOrganTests {
         audioInputManager.audioStream.emit(newStreamFrame)
         sutScope.advanceUntilIdle()
 
-        verify { subscriber1.new(newColor) }
-        verify { subscriber2.new(newColor) }
-        verify { server.new(newColor) }
+        eventually { subscriber1.new(newColor) }
+        eventually { subscriber2.new(newColor) }
+        eventually { server.new(newColor) }
     }
 
     @Test

--- a/src/test/kotlin/lightOrgan/spectrum/SpectrumManagerIntegrationTests.kt
+++ b/src/test/kotlin/lightOrgan/spectrum/SpectrumManagerIntegrationTests.kt
@@ -2,6 +2,7 @@ package lightOrgan.spectrum
 
 import dsp.filtering.config.FilterConfig
 import dsp.filtering.config.FilterFamily
+import dsp.windowing.WindowType
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -33,6 +34,7 @@ class SpectrumManagerIntegrationTests {
         every { config.interpolatedSampleSize } returns sampleRate.toInt()
         every { config.highPassFilter } returns null
         every { config.lowPassFilter } returns null
+        every { config.window } returns WindowType.Hann
     }
 
     private fun createSUT(): SpectrumManager {

--- a/src/test/kotlin/lightOrgan/spectrum/SpectrumManagerUnitTests.kt
+++ b/src/test/kotlin/lightOrgan/spectrum/SpectrumManagerUnitTests.kt
@@ -9,9 +9,8 @@ import dsp.filtering.OrderedFilter
 import dsp.filtering.config.FilterBuilder
 import dsp.filtering.config.FilterConfig
 import dsp.windowing.Window
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
+import dsp.windowing.WindowType
+import io.mockk.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import toolkit.monkeyTest.*
@@ -34,6 +33,7 @@ class SpectrumManagerUnitTests {
     private val format1Frame2 = nextAudioFrame(sampleRate = format1.sampleRate)
     private val format2Frame1 = nextAudioFrame(sampleRate = format2.sampleRate)
 
+    private val windowType: WindowType = mockk()
     private val interpolatedSampleSize = nextPositiveInt()
     private val lowPassFilterConfig: FilterConfig = mockk()
     private val highPassFilterConfig: FilterConfig = mockk()
@@ -56,6 +56,7 @@ class SpectrumManagerUnitTests {
         every { config.interpolatedSampleSize } returns interpolatedSampleSize
         every { config.lowPassFilter } returns lowPassFilterConfig
         every { config.highPassFilter } returns highPassFilterConfig
+        every { config.window } returns windowType
 
         every { filterBuilder.build(lowPassFilterConfig, format1.sampleRate) } returns lowPassFilter1
         every { filterBuilder.build(highPassFilterConfig, format1.sampleRate) } returns highPassFilter1
@@ -72,7 +73,9 @@ class SpectrumManagerUnitTests {
         every { highPassFilter2.filter(any()) } returns highPassedSamples
         every { highPassFilter2.sampleRate } returns format2.sampleRate
 
+        every { audioBuffer.size = any() } just runs
         every { audioBuffer.append(any()) } returns bufferedFrame
+        every { windowType.createWindow() } returns window
         every { window.appliedTo(any()) } returns windowedSamples
         every { window.magnitudeCorrectionFactor(any()) } returns 1f
         every { interpolator.interpolate(any(), any()) } returns interpolatedSamples

--- a/src/test/kotlin/toolkit/monkeyTest/NextAudioFrame.kt
+++ b/src/test/kotlin/toolkit/monkeyTest/NextAudioFrame.kt
@@ -5,6 +5,16 @@ import audio.samples.AudioFrame
 import toolkit.generators.WaveForm
 
 fun nextAudioFrame(
+    samples: FloatArray = nextFloatArray(),
+    format: AudioFormat = nextAudioFormat()
+): AudioFrame {
+    return AudioFrame(
+        samples = samples,
+        format = format
+    )
+}
+
+fun nextAudioFrame(
     channels: List<FloatArray> = listOf(nextFloatArray()),
     sampleRate: Float = nextPositiveInt().toFloat(),
     bitDepth: Int = nextPositiveInt()

--- a/src/test/kotlin/toolkit/monkeyTest/NextConfig.kt
+++ b/src/test/kotlin/toolkit/monkeyTest/NextConfig.kt
@@ -2,6 +2,7 @@ package toolkit.monkeyTest
 
 import config.Config
 import config.children.Client
+import dsp.windowing.WindowType
 import gui.dashboard.tiles.spectrum.SpectrumGuiConfig
 import kotlinx.coroutines.flow.MutableStateFlow
 import lightOrgan.spectrum.SpectrumConfig
@@ -18,6 +19,7 @@ fun nextConfig(
             interpolatedSampleSize = nextPositiveInt(),
             highPassFilter = nextFilterConfig(),
             lowPassFilter = nextFilterConfig(),
+            window = nextEnum<WindowType>()
         ),
         spectrumGui = SpectrumGuiConfig(
             scale = Random.nextFloat(),


### PR DESCRIPTION
I'm now making the size mutable at runtime. This paves the way for decimation which will yield different sample sizes and configuration more broadly.

I also fixed a Light Organ test that was failing. I had overlooked it.