### PR TITLE
Optimized input line read call

### DIFF
--- a/src/main/kotlin/audio/audioInput/AudioInput.kt
+++ b/src/main/kotlin/audio/audioInput/AudioInput.kt
@@ -13,7 +13,7 @@ import wrappers.sound.InputLine
 class AudioInput(
     private val inputLine: InputLine,
     private val sampleNormalizer: SampleNormalizer,
-    private val scope: CoroutineScope = CoroutineScope(SupervisorJob())
+    private val scope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 ) {
 
     private val listeningJob = MutableStateFlow<Job?>(null)

--- a/src/main/kotlin/wrappers/sound/InputLine.kt
+++ b/src/main/kotlin/wrappers/sound/InputLine.kt
@@ -1,6 +1,5 @@
 package wrappers.sound
 
-import logging.Logger
 import java.nio.ByteOrder
 import javax.sound.sampled.TargetDataLine
 
@@ -12,7 +11,6 @@ import javax.sound.sampled.TargetDataLine
 class InputLine(
     val name: String,
     private val dataLine: TargetDataLine,
-    private val minimumReadSize: Int = 2048, // TODO: Eliminate me
     private val bufferSize: Int = 8192, // ENHANCEMENT: Make the buffer size configurable in the GUI.
 ) {
 
@@ -20,10 +18,6 @@ class InputLine(
     val bitDepth = dataLine.format.sampleSizeInBits
     val channels = dataLine.format.channels
     val byteOrder: ByteOrder = if (dataLine.format.isBigEndian) ByteOrder.BIG_ENDIAN else ByteOrder.LITTLE_ENDIAN
-
-    init {
-        require(bufferSize >= minimumReadSize) { "Minimum read size ($minimumReadSize) must not exceed buffer size ($bufferSize)" }
-    }
 
     // Lifecycle
     fun start() {
@@ -44,18 +38,17 @@ class InputLine(
     // Reading
     @Suppress("RedundantSuspendModifier")
     suspend fun read(): ReadResult {
-        val available = dataLine.available()
-        val readSize = if (available > minimumReadSize) available else minimumReadSize
-        val bufferWasFull = available >= bufferSize
+        val frameSize = dataLine.format.frameSize
+        require(frameSize > 0) { "Cannot read: audio format has no valid frame size ($frameSize)" }
 
-        val readData = ByteArray(readSize)
-        val lengthRead = dataLine.read(readData, 0, readSize) // This will block until readSize bytes are available
+        val firstFrame = ByteArray(frameSize)
+        dataLine.read(firstFrame, 0, frameSize)
 
-        if (lengthRead != readSize) {
-            Logger.warning("Read $lengthRead bytes instead of $readSize bytes")
-        }
+        val remaining = dataLine.available()
+        val remainingFrames = ByteArray(remaining)
+        dataLine.read(remainingFrames, 0, remaining)
 
-        return ReadResult(readData, bufferWasFull)
+        return ReadResult(firstFrame + remainingFrames, (frameSize + remaining) >= bufferSize)
     }
 
     class ReadResult(

--- a/src/main/kotlin/wrappers/sound/InputLine.kt
+++ b/src/main/kotlin/wrappers/sound/InputLine.kt
@@ -1,8 +1,5 @@
 package wrappers.sound
 
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import logging.Logger
 import java.nio.ByteOrder
 import javax.sound.sampled.TargetDataLine
@@ -15,9 +12,8 @@ import javax.sound.sampled.TargetDataLine
 class InputLine(
     val name: String,
     private val dataLine: TargetDataLine,
-    private val minimumReadSize: Int = 2048, // ENHANCEMENT: Make the minimum read size configurable in the GUI.
+    private val minimumReadSize: Int = 2048, // TODO: Eliminate me
     private val bufferSize: Int = 8192, // ENHANCEMENT: Make the buffer size configurable in the GUI.
-    private val readDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) {
 
     val sampleRate = dataLine.format.sampleRate
@@ -46,7 +42,8 @@ class InputLine(
     }
 
     // Reading
-    suspend fun read(): ReadResult = withContext(readDispatcher) {
+    @Suppress("RedundantSuspendModifier")
+    suspend fun read(): ReadResult {
         val available = dataLine.available()
         val readSize = if (available > minimumReadSize) available else minimumReadSize
         val bufferWasFull = available >= bufferSize
@@ -58,7 +55,7 @@ class InputLine(
             Logger.warning("Read $lengthRead bytes instead of $readSize bytes")
         }
 
-        return@withContext ReadResult(readData, bufferWasFull)
+        return ReadResult(readData, bufferWasFull)
     }
 
     class ReadResult(

--- a/src/test/kotlin/wrappers/sound/FakeTargetDataLine.kt
+++ b/src/test/kotlin/wrappers/sound/FakeTargetDataLine.kt
@@ -1,0 +1,59 @@
+package wrappers.sound
+
+import io.mockk.every
+import io.mockk.mockk
+import toolkit.monkeyTest.nextPositiveFloat
+import toolkit.monkeyTest.nextPositiveInt
+import java.util.concurrent.LinkedBlockingQueue
+import javax.sound.sampled.TargetDataLine
+import kotlin.random.Random.Default.nextBoolean
+
+class FakeTargetDataLine(
+    val dataLine: TargetDataLine = mockk(),
+    val format: javax.sound.sampled.AudioFormat = mockk()
+) {
+
+    var sampleRate = nextPositiveFloat()
+    var sampleSizeInBits = nextPositiveInt()
+    var channels = nextPositiveInt()
+    var isBigEndian = nextBoolean()
+
+    private val buffer: LinkedBlockingQueue<Byte> = LinkedBlockingQueue()
+
+    init {
+        // Format
+        every { dataLine.format } returns format
+        every { format.sampleRate } answers { sampleRate }
+        every { format.sampleSizeInBits } answers { sampleSizeInBits }
+        every { format.channels } answers { channels }
+        every { format.isBigEndian } answers { isBigEndian }
+        every { format.frameSize } returns 1 // To keep things simple
+
+        // Lifecycle
+        every { dataLine.open(any(), any()) } returns Unit
+        every { dataLine.start() } returns Unit
+        every { dataLine.stop() } returns Unit
+        every { dataLine.close() } returns Unit
+
+        // Reading
+        every { dataLine.available() } answers { buffer.size }
+        every { dataLine.read(any(), any(), any()) } answers {
+            val dest = firstArg<ByteArray>()
+            val offset = secondArg<Int>()
+            val length = thirdArg<Int>()
+
+            dest[offset] = buffer.take()
+            var bytesRead = 1
+            while (bytesRead < length && buffer.isNotEmpty()) {
+                dest[offset + bytesRead] = buffer.poll() ?: break
+                bytesRead++
+            }
+            bytesRead
+        }
+    }
+
+    fun queue(data: ByteArray) {
+        data.forEach { buffer.put(it) }
+    }
+
+}

--- a/src/test/kotlin/wrappers/sound/InputLineTests.kt
+++ b/src/test/kotlin/wrappers/sound/InputLineTests.kt
@@ -2,7 +2,6 @@ package wrappers.sound
 
 import io.mockk.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
@@ -50,8 +49,7 @@ class InputLineTests {
             name = name,
             dataLine = dataLine,
             minimumReadSize = minimumReadSize,
-            bufferSize = bufferSize,
-            readDispatcher = UnconfinedTestDispatcher()
+            bufferSize = bufferSize
         )
     }
 

--- a/src/test/kotlin/wrappers/sound/InputLineTests.kt
+++ b/src/test/kotlin/wrappers/sound/InputLineTests.kt
@@ -1,42 +1,36 @@
 package wrappers.sound
 
-import io.mockk.*
-import kotlinx.coroutines.ExperimentalCoroutinesApi
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.verify
+import io.mockk.verifyOrder
+import kotlinx.coroutines.*
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import toolkit.monkeyTest.*
+import toolkit.monkeyTest.nextByteArray
+import toolkit.monkeyTest.nextException
+import toolkit.monkeyTest.nextPositiveInt
+import toolkit.monkeyTest.nextString
 import java.nio.ByteOrder
-import javax.sound.sampled.TargetDataLine
-import kotlin.random.Random.Default.nextBoolean
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class InputLineTests {
 
     private val name = nextString("name")
-    private val dataLine: TargetDataLine = mockk()
-    private val minimumReadSize = nextPositiveInt()
-    private val bufferSize = minimumReadSize * 2 // easy math
+    private lateinit var fakeDataLine: FakeTargetDataLine
+    private val bufferSize = nextPositiveInt(min = 16)
 
-    private val format: javax.sound.sampled.AudioFormat = mockk()
     private val exception = nextException()
 
     @BeforeEach
     fun setupHappyPath() {
-        every { dataLine.format } returns format
-        every { format.sampleRate } returns nextPositiveFloat()
-        every { format.sampleSizeInBits } returns nextPositiveInt()
-        every { format.channels } returns nextPositiveInt()
-        every { format.isBigEndian } returns nextBoolean()
-
-        every { dataLine.open(any(), any()) } returns Unit
-        every { dataLine.start() } returns Unit
-        every { dataLine.read(any(), any(), any()) } returns nextPositiveInt()
-        every { dataLine.stop() } returns Unit
-        every { dataLine.close() } returns Unit
+        fakeDataLine = FakeTargetDataLine()
     }
 
     @AfterEach
@@ -47,18 +41,9 @@ class InputLineTests {
     private fun createSUT(): InputLine {
         return InputLine(
             name = name,
-            dataLine = dataLine,
-            minimumReadSize = minimumReadSize,
+            dataLine = fakeDataLine.dataLine,
             bufferSize = bufferSize
         )
-    }
-
-    // Init
-    @Test
-    fun `the buffer size must be greater than or equal to the minimum read size`() {
-        assertDoesNotThrow { InputLine(name, dataLine, minimumReadSize = 2, bufferSize = 3) }
-        assertDoesNotThrow { InputLine(name, dataLine, minimumReadSize = 2, bufferSize = 2) }
-        assertThrows<IllegalArgumentException> { InputLine(name, dataLine, minimumReadSize = 2, bufferSize = 1) }
     }
 
     // Details
@@ -73,26 +58,26 @@ class InputLineTests {
     fun `get the sample rate`() {
         val sut = createSUT()
 
-        assertEquals(format.sampleRate, sut.sampleRate)
+        assertEquals(fakeDataLine.sampleRate, sut.sampleRate)
     }
 
     @Test
     fun `get the bit depth`() {
         val sut = createSUT()
 
-        assertEquals(format.sampleSizeInBits, sut.bitDepth)
+        assertEquals(fakeDataLine.sampleSizeInBits, sut.bitDepth)
     }
 
     @Test
     fun `get the number of channels`() {
         val sut = createSUT()
 
-        assertEquals(format.channels, sut.channels)
+        assertEquals(fakeDataLine.channels, sut.channels)
     }
 
     @Test
     fun `given the format is big endian, then the byte order is big endian`() {
-        every { format.isBigEndian } returns true
+        fakeDataLine.isBigEndian = true
         val sut = createSUT()
 
         assertEquals(ByteOrder.BIG_ENDIAN, sut.byteOrder)
@@ -100,7 +85,7 @@ class InputLineTests {
 
     @Test
     fun `given the format not big endian, then the byte order is little endian`() {
-        every { format.isBigEndian } returns false
+        fakeDataLine.isBigEndian = false
         val sut = createSUT()
 
         assertEquals(ByteOrder.LITTLE_ENDIAN, sut.byteOrder)
@@ -108,141 +93,96 @@ class InputLineTests {
 
     // Lifecycle
     @Test
-    fun `open and start the data line`() {
+    fun `start the input`() {
         val sut = createSUT()
 
         sut.start()
 
         verifyOrder {
-            dataLine.open(format, bufferSize)
-            dataLine.start()
+            fakeDataLine.dataLine.open(fakeDataLine.format, bufferSize)
+            fakeDataLine.dataLine.start()
         }
     }
 
     @Test
-    fun `when open fails, then stop and rethrow`() {
+    fun `given the data line fails to open when starting the input, then throw`() {
         val sut = createSUT()
-        every { dataLine.open(any(), any()) } throws exception
+        every { fakeDataLine.dataLine.open(any(), any()) } throws exception
 
-        val actual = assertThrows<Exception> { sut.start() }
-
-        verify { dataLine.stop() }
-        verify { dataLine.close() }
-        assertEquals(exception, actual)
+        assertThrows<Exception> { sut.start() }
     }
 
     @Test
-    fun `when start fails, then stop and rethrow`() {
+    fun `given the data line fails to start when starting the input, then close the line and throw`() {
         val sut = createSUT()
-        every { dataLine.start() } throws exception
+        every { fakeDataLine.dataLine.start() } throws exception
 
-        val actual = assertThrows<Exception> { sut.start() }
+        assertThrows<Exception> { sut.start() }
 
-        verify { dataLine.stop() }
-        verify { dataLine.close() }
-        assertEquals(exception, actual)
+        verify { fakeDataLine.dataLine.close() }
     }
 
     @Test
-    fun `stop stops and closes the data line`() {
+    fun `stop the input`() {
         val sut = createSUT()
 
         sut.stop()
 
         verifyOrder {
-            dataLine.stop()
-            dataLine.close()
+            fakeDataLine.dataLine.stop()
+            fakeDataLine.dataLine.close()
         }
     }
 
     // Read - data
     @Test
-    fun `when no data is available, read the minimum size`() = runTest {
+    fun `given data is waiting to be read, read returns the data`() = runTest {
         val sut = createSUT()
-
-        every { dataLine.available() } returns 0
-
-        val bytesToBeRead = nextByteArray(minimumReadSize)
-        every { dataLine.read(any(), 0, minimumReadSize) } answers {
-            bytesToBeRead.copyInto(firstArg<ByteArray>())
-            bytesToBeRead.size
-        }
+        val data = nextByteArray(bufferSize)
+        fakeDataLine.queue(data)
 
         val result = sut.read()
 
-        assertArrayEquals(bytesToBeRead, result.data)
+        assertArrayEquals(data, result.data)
     }
 
     @Test
-    fun `when available data equals the minimum, read the minimum size`() = runTest {
+    fun `given no data is waiting to be read, read waits until it can return the data`() = runTest {
         val sut = createSUT()
+        val data = nextByteArray(10)
 
-        every { dataLine.available() } returns minimumReadSize
+        val result = async(Dispatchers.Default) { sut.read() }
 
-        val bytesToBeRead = nextByteArray(minimumReadSize)
-        every { dataLine.read(any(), 0, minimumReadSize) } answers {
-            bytesToBeRead.copyInto(firstArg<ByteArray>())
-            bytesToBeRead.size
-        }
+        delay(50.milliseconds)
+        assertFalse(result.isCompleted)
+
+        fakeDataLine.queue(data)
+
+        val readResult = withTimeout(1.seconds) { result.await() }
+        assertArrayEquals(data, readResult.data)
+    }
+
+    // Read - buffer state
+    @Test
+    fun `buffer was not full when data is less than buffer size`() = runTest {
+        val sut = createSUT()
+        val partialData = nextByteArray(bufferSize - 1)
+        fakeDataLine.queue(partialData)
 
         val result = sut.read()
 
-        assertArrayEquals(bytesToBeRead, result.data)
+        assertFalse(result.bufferWasFull)
     }
 
     @Test
-    fun `when available data exceeds the minimum, read all available`() = runTest {
+    fun `buffer was full when data equals buffer size`() = runTest {
         val sut = createSUT()
-        val availableBytes = minimumReadSize + 1
-
-        every { dataLine.available() } returns availableBytes
-
-        val bytesToBeRead = nextByteArray(availableBytes)
-        every { dataLine.read(any(), 0, availableBytes) } answers {
-            bytesToBeRead.copyInto(firstArg<ByteArray>())
-            bytesToBeRead.size
-        }
+        val fullData = nextByteArray(bufferSize)
+        fakeDataLine.queue(fullData)
 
         val result = sut.read()
 
-        assertArrayEquals(bytesToBeRead, result.data)
+        assertTrue(result.bufferWasFull)
     }
-
-    // Read - buffer status
-    @Test
-    fun `when available data is less than the buffer size, the buffer was not full`() = runTest {
-        val sut = createSUT()
-        val availableBytes = bufferSize - 1
-        val bytesToBeRead = nextByteArray(availableBytes)
-
-        every { dataLine.available() } returns availableBytes
-        every { dataLine.read(any(), 0, availableBytes) } answers {
-            bytesToBeRead.copyInto(firstArg<ByteArray>())
-            bytesToBeRead.size
-        }
-
-        val result = sut.read()
-
-        assertEquals(false, result.bufferWasFull)
-    }
-
-
-    @Test
-    fun `when available data is equal to the buffer size, the buffer was full`() = runTest {
-        val sut = createSUT()
-        val availableBytes = bufferSize
-        val bytesToBeRead = nextByteArray(availableBytes)
-
-        every { dataLine.available() } returns availableBytes
-        every { dataLine.read(any(), 0, availableBytes) } answers {
-            bytesToBeRead.copyInto(firstArg<ByteArray>())
-            bytesToBeRead.size
-        }
-
-        val result = sut.read()
-
-        assertEquals(true, result.bufferWasFull)
-    }
-
 
 }


### PR DESCRIPTION
Barring unforeseen bugs, this is about as good as read via JavaSound will get. Basically, we block until data is available, but read the ENTIRETY of available data.

This makes the audio capture maximally performant. If the audio driver/OS gives us 1 byte at time, then we will deliver each byte one by one. This means that consumers need to be HIGHLY PERFORMANT or they will fall behind and drop frames.