### PR TITLE
Fixed sequence start/stop bug

### DIFF
--- a/src/main/kotlin/utilities/coroutines/MapSequenced.kt
+++ b/src/main/kotlin/utilities/coroutines/MapSequenced.kt
@@ -6,15 +6,16 @@ import kotlinx.coroutines.flow.map
 fun <T, R> Flow<Sequenced<T>>.mapSequenced(
     gapDetector: SequenceGapDetector = SequenceGapDetector(),
     onGap: (size: Long) -> Unit = {},
+    onReset: () -> Unit = {},
     transform: suspend (T) -> R
 ): Flow<Sequenced<R>> {
     var outgoingNumber = 0L
 
     return map { incoming ->
-        val gap = gapDetector.check(incoming.sequenceNumber)
-
-        if (gap != 0L) {
-            onGap(gap)
+        when (val result = gapDetector.check(incoming.sequenceNumber)) {
+            is SequenceCheck.Ok -> {}
+            is SequenceCheck.Gap -> onGap(result.size)
+            is SequenceCheck.Reset -> onReset()
         }
 
         Sequenced(outgoingNumber++, transform(incoming.value))

--- a/src/main/kotlin/utilities/coroutines/OnEachSequenced.kt
+++ b/src/main/kotlin/utilities/coroutines/OnEachSequenced.kt
@@ -6,13 +6,14 @@ import kotlinx.coroutines.flow.onEach
 fun <T> Flow<Sequenced<T>>.onEachSequenced(
     gapDetector: SequenceGapDetector = SequenceGapDetector(),
     onGap: (size: Long) -> Unit = {},
+    onReset: () -> Unit = {},
     action: suspend (T) -> Unit
 ): Flow<Sequenced<T>> {
     return onEach { incoming ->
-        val gap = gapDetector.check(incoming.sequenceNumber)
-
-        if (gap != 0L) {
-            onGap(gap)
+        when (val result = gapDetector.check(incoming.sequenceNumber)) {
+            is SequenceCheck.Ok -> {}
+            is SequenceCheck.Gap -> onGap(result.size)
+            is SequenceCheck.Reset -> onReset()
         }
 
         action(incoming.value)

--- a/src/main/kotlin/utilities/coroutines/SequenceGapDetector.kt
+++ b/src/main/kotlin/utilities/coroutines/SequenceGapDetector.kt
@@ -1,18 +1,28 @@
 package utilities.coroutines
 
+sealed class SequenceCheck {
+    data object Ok : SequenceCheck()
+    data class Gap(val size: Long) : SequenceCheck()
+    data object Reset : SequenceCheck()
+}
+
 class SequenceGapDetector {
 
-    private var expected: Long? = null
+    private var expectedSequenceNumber: Long? = null
 
-    fun check(sequenceNumber: Long): Long {
-        val expected = this.expected ?: sequenceNumber
-        val delta = sequenceNumber - expected
+    fun check(sequenceNumber: Long): SequenceCheck {
+        val expected = expectedSequenceNumber
 
-        if (delta >= 0) {
-            this.expected = sequenceNumber + 1
+        val result = when {
+            expected == null -> SequenceCheck.Ok
+            sequenceNumber < expected -> SequenceCheck.Reset
+            sequenceNumber > expected -> SequenceCheck.Gap(sequenceNumber - expected)
+            else -> SequenceCheck.Ok
         }
 
-        return delta
+        expectedSequenceNumber = sequenceNumber + 1
+
+        return result
     }
 
 }

--- a/src/test/kotlin/utilities/coroutines/MapSequencedIntegrationTests.kt
+++ b/src/test/kotlin/utilities/coroutines/MapSequencedIntegrationTests.kt
@@ -1,35 +1,19 @@
 package utilities.coroutines
 
-import io.mockk.clearAllMocks
-import io.mockk.every
-import io.mockk.mockk
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import toolkit.monkeyTest.nextInt
 
-class MapSequencedTests {
-
-    private val gapDetector: SequenceGapDetector = mockk()
+class MapSequencedIntegrationTests {
 
     private val number1 = nextInt()
     private val number2 = nextInt()
 
-    @BeforeEach
-    fun setup() {
-        every { gapDetector.check(any()) } returns 0L
-    }
-
-    @AfterEach
-    fun tearDown() {
-        clearAllMocks()
-    }
-
+    // Normal operation
     @Test
     fun `transform the inner value`() = runTest {
         val result = flowOf(number1.asSequenced(0L))
@@ -51,19 +35,49 @@ class MapSequencedTests {
         )
     }
 
+    // Gap
     @Test
     fun `report when gaps occur`() = runTest {
         val gaps = mutableListOf<Long>()
-        every { gapDetector.check(0) } returns 0L
-        every { gapDetector.check(2) } returns 1L
 
         flowOf(number1.asSequenced(0), number2.asSequenced(2))
-            .mapSequenced(gapDetector = gapDetector, transform = { it }, onGap = { gaps.add(it) })
+            .mapSequenced(transform = { it }, onGap = { gaps.add(it) })
+            .toList()
+
+        assertEquals(listOf(1L), gaps)
+    }
+
+    // Reset
+    @Test
+    fun `report when reset occurs`() = runTest {
+        var resetCount = 0
+
+        flowOf(number1.asSequenced(0), number2.asSequenced(0))
+            .mapSequenced(onReset = { resetCount++ }, transform = { it })
+            .toList()
+
+        assertEquals(1, resetCount)
+    }
+
+    @Test
+    fun `outgoing sequence continues through upstream reset`() = runTest {
+        val results = flowOf(
+            number1.asSequenced(0),
+            number2.asSequenced(1),
+            number1.asSequenced(0),
+            number2.asSequenced(1)
+        )
+            .mapSequenced(transform = { it })
             .toList()
 
         assertEquals(
-            listOf(1L),
-            gaps
+            listOf(
+                Sequenced(0L, number1),
+                Sequenced(1L, number2),
+                Sequenced(2L, number1),
+                Sequenced(3L, number2)
+            ),
+            results
         )
     }
 

--- a/src/test/kotlin/utilities/coroutines/OnEachSequencedIntegrationTests.kt
+++ b/src/test/kotlin/utilities/coroutines/OnEachSequencedIntegrationTests.kt
@@ -1,33 +1,16 @@
 package utilities.coroutines
 
-import io.mockk.clearAllMocks
-import io.mockk.every
-import io.mockk.mockk
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import toolkit.monkeyTest.nextString
 
-class OnEachSequencedTests {
-
-    private val gapDetector: SequenceGapDetector = mockk()
+class OnEachSequencedIntegrationTests {
 
     private val string1 = nextString("1")
     private val string2 = nextString("2")
-
-    @BeforeEach
-    fun setup() {
-        every { gapDetector.check(any()) } returns 0L
-    }
-
-    @AfterEach
-    fun tearDown() {
-        clearAllMocks()
-    }
 
     @Test
     fun `perform the action with the inner value`() = runTest {
@@ -44,19 +27,28 @@ class OnEachSequencedTests {
     }
 
     @Test
-    fun `report when gaps occurs`() = runTest {
+    fun `report when gaps occur`() = runTest {
         val gaps = mutableListOf<Long>()
-        every { gapDetector.check(0) } returns 0L
-        every { gapDetector.check(2) } returns 1L
 
         flowOf(string1.asSequenced(0), string2.asSequenced(2))
-            .onEachSequenced(gapDetector = gapDetector, action = {}, onGap = { gaps.add(it) })
+            .onEachSequenced(action = {}, onGap = { gaps.add(it) })
             .toList()
 
         assertEquals(
             listOf(1L),
             gaps
         )
+    }
+
+    @Test
+    fun `report when reset occurs`() = runTest {
+        var resetCount = 0
+
+        flowOf(string1.asSequenced(5), string2.asSequenced(0))
+            .onEachSequenced(action = {}, onReset = { resetCount++ })
+            .toList()
+
+        assertEquals(1, resetCount)
     }
 
 }

--- a/src/test/kotlin/utilities/coroutines/SequenceGapDetectorTests.kt
+++ b/src/test/kotlin/utilities/coroutines/SequenceGapDetectorTests.kt
@@ -9,68 +9,68 @@ class SequenceGapDetectorTests {
         return SequenceGapDetector()
     }
 
-    // No gap
+    // Ok
     @Test
-    fun `first check has no gap`() {
+    fun `first check is ok`() {
         val sut = createSUT()
 
         val result = sut.check(5L)
 
-        assertEquals(0L, result)
+        assertEquals(SequenceCheck.Ok, result)
     }
 
     @Test
-    fun `sequential numbers have no gap`() {
+    fun `sequential numbers are ok`() {
         val sut = createSUT()
         sut.check(5L)
 
         val result = sut.check(6L)
 
-        assertEquals(0L, result)
+        assertEquals(SequenceCheck.Ok, result)
     }
 
-    // Forward gap
+    // Gap
     @Test
-    fun `a forward gap is reported`() {
+    fun `when there is a gap in the ascending sequence, report the gap`() {
         val sut = createSUT()
         sut.check(0L)
 
         val result = sut.check(5L)
 
-        assertEquals(4L, result)
+        assertEquals(SequenceCheck.Gap(4L), result)
     }
 
     @Test
-    fun `after a forward gap, sequential numbers resume normally`() {
+    fun `after a gap, sequential numbers resume normally`() {
         val sut = createSUT()
         sut.check(0L)
         sut.check(5L)
 
         val result = sut.check(6L)
 
-        assertEquals(0L, result)
+        assertEquals(SequenceCheck.Ok, result)
     }
 
-    // Backward gap
+    // Reset
     @Test
-    fun `a backwards gap is reported`() {
+    fun `when there is a decrease in the sequence, report a reset`() {
         val sut = createSUT()
         sut.check(5L)
 
-        val result = sut.check(0L)
+        val result = sut.check(1L)
 
-        assertEquals(-6L, result)
+        assertEquals(SequenceCheck.Reset, result)
     }
 
     @Test
-    fun `after a backwards gap, sequential numbers resume normally`() {
+    fun `after a reset, sequential numbers resume normally`() {
         val sut = createSUT()
         sut.check(5L)
         sut.check(0L)
 
-        val result = sut.check(6L)
+        val result = sut.check(1L)
 
-        assertEquals(0L, result)
+        assertEquals(SequenceCheck.Ok, result)
     }
-    
+
 }


### PR DESCRIPTION
If you stopped something like the audio input, the sequence number may reset. If it does, the dowstream sequence watcher will think that we have had a NEGATIVE gap. While I'd like to be honest about negative gaps, I think we must assume its a reset (as I'm not sure that flows can be out of order). And in any case, an explicit "reset" call could be dropped, so we'd need a fallback.

In the end, assuming reset on negative gap seemed like the best solution.