### PR TITLE
Automatic audio input

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -103,7 +103,6 @@ private fun launchHeadless(
     })
 
     runBlocking {
-        inputManager.selectDefaultInput()
         inputManager.startListening()
         gatewayManager.connect()
         awaitCancellation()

--- a/src/main/kotlin/audio/audioInput/AudioInputFinder.kt
+++ b/src/main/kotlin/audio/audioInput/AudioInputFinder.kt
@@ -11,8 +11,8 @@ class AudioInputFinder(
         return allDevices.flatMap { device -> device.inputs }
     }
 
-    fun findDefaultInput(): AudioInput {
-        return findAll().firstOrNull() ?: throw Exception("No audio input found.")
+    fun findDefaultInput(): AudioInput? {
+        return findAll().firstOrNull()
     }
 
 }

--- a/src/main/kotlin/gui/dashboard/tiles/audioInput/AudioInputTile.kt
+++ b/src/main/kotlin/gui/dashboard/tiles/audioInput/AudioInputTile.kt
@@ -33,13 +33,7 @@ fun AudioInputTile(
 
         SimpleSpacer(dpSize = 12)
 
-        if (inputDetails == null) {
-            SimpleButton(
-                title = "Find Input",
-                isLoading = false,
-                action = { viewModel.findInput() }
-            )
-        } else if (isListening) {
+        if (isListening) {
             SimpleButton(
                 title = "Stop",
                 isLoading = false,

--- a/src/main/kotlin/gui/dashboard/tiles/audioInput/AudioInputTileViewModel.kt
+++ b/src/main/kotlin/gui/dashboard/tiles/audioInput/AudioInputTileViewModel.kt
@@ -18,10 +18,6 @@ class AudioInputTileViewModel(
     val inputDetails: StateFlow<AudioInputDetails?> = audioInputManager.inputDetails
     val isListening: StateFlow<Boolean> = audioInputManager.isListening
 
-    fun findInput() {
-        audioInputManager.selectDefaultInput()
-    }
-
     fun start() {
         scope.launch {
             try {

--- a/src/main/kotlin/lightOrgan/input/AudioInputManager.kt
+++ b/src/main/kotlin/lightOrgan/input/AudioInputManager.kt
@@ -28,14 +28,12 @@ class AudioInputManager(
         .flatMapLatest { it?.audioStream ?: emptyFlow() }
         .shareIn(scope, SharingStarted.Eagerly)
 
-    // Input selection
-    fun selectDefaultInput() {
-        currentAudioInput.value?.stop()
-        currentAudioInput.value = audioInputFinder.findDefaultInput()
-    }
-
     // Start-stop
     fun startListening() {
+        if (currentAudioInput.value == null) {
+            currentAudioInput.value = audioInputFinder.findDefaultInput()
+        }
+
         val input = currentAudioInput.value ?: throw IllegalStateException("Cannot start listening. No input selected.")
         input.start()
     }

--- a/src/main/kotlin/logging/Logger.kt
+++ b/src/main/kotlin/logging/Logger.kt
@@ -1,13 +1,13 @@
 package logging
 
-enum class LogLevel { ERROR, WARNING, SUCCESS, DEBUG }
+enum class LogLevel { OFF, ERROR, WARNING, SUCCESS, DEBUG }
 
 object Logger {
 
     var level: LogLevel = LogLevel.ERROR
 
     fun error(message: String) {
-        println("${LogColor.Red.code}ERROR: $message${LogColor.Default.code}")
+        if (level >= LogLevel.ERROR) println("${LogColor.Red.code}ERROR: $message${LogColor.Default.code}")
     }
 
     fun error(message: String, throwable: Throwable) {

--- a/src/test/kotlin/audio/audioInput/AudioInputFinderTests.kt
+++ b/src/test/kotlin/audio/audioInput/AudioInputFinderTests.kt
@@ -2,8 +2,6 @@ package audio.audioInput
 
 import audio.audioDevice.AudioDevice
 import audio.audioDevice.AudioDeviceFinder
-import audio.audioInput.AudioInput
-import audio.audioInput.AudioInputFinder
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -11,7 +9,7 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.assertNull
 
 class AudioInputFinderTests {
 
@@ -77,12 +75,14 @@ class AudioInputFinderTests {
     }
 
     @Test
-    fun `given there are no inputs, when finding default input, then throw an exception`() {
+    fun `given there are no inputs, when finding default input, then return null`() {
         val sut = createSUT()
         every { audioDevice1.inputs } returns emptyList()
         every { audioDevice2.inputs } returns emptyList()
 
-        assertThrows<Exception> { sut.findDefaultInput() }
+        val actual = sut.findDefaultInput()
+
+        assertNull(actual)
     }
 
 }

--- a/src/test/kotlin/gui/dashboard/tiles/audioInput/AudioInputTileViewModelTests.kt
+++ b/src/test/kotlin/gui/dashboard/tiles/audioInput/AudioInputTileViewModelTests.kt
@@ -35,7 +35,6 @@ class AudioInputTileViewModelTests {
 
     @BeforeEach
     fun setup() {
-        every { audioInputManager.selectDefaultInput() } returns Unit
         every { audioInputManager.inputDetails } returns audioInputDetailsFlow
         every { audioInputManager.isListening } returns isListeningFlow
 
@@ -55,16 +54,6 @@ class AudioInputTileViewModelTests {
             snackbarController = snackbarController,
             scope = sutScope
         )
-    }
-
-    // Find input
-    @Test
-    fun `attempt to find the default input`() = runTest {
-        val sut = createSUT()
-
-        sut.findInput()
-
-        verify { audioInputManager.selectDefaultInput() }
     }
 
     // Input Details

--- a/src/test/kotlin/lightOrgan/gateway/GatewayManagerTests.kt
+++ b/src/test/kotlin/lightOrgan/gateway/GatewayManagerTests.kt
@@ -18,7 +18,7 @@ import toolkit.monkeyTest.nextGatewayConfig
 @OptIn(ExperimentalCoroutinesApi::class)
 class GatewayManagerTests {
 
-    private val config = nextGatewayConfig()
+    private val config = nextGatewayConfig().copy(autoReconnect = false)
     private lateinit var fakeGatewayFinder: FakeGatewayFinder
 
     @BeforeEach

--- a/src/test/kotlin/lightOrgan/input/AudioInputManagerFixture.kt
+++ b/src/test/kotlin/lightOrgan/input/AudioInputManagerFixture.kt
@@ -22,7 +22,6 @@ data class AudioInputManagerFixture(
                 audioStream = MutableSharedFlow(extraBufferCapacity = 1)
             )
 
-            every { fixture.mock.selectDefaultInput() } returns Unit
             every { fixture.mock.inputDetails } returns fixture.inputDetailsFlow
             every { fixture.mock.isListening } returns fixture.isListeningFlow
             every { fixture.mock.audioStream } returns fixture.audioStream

--- a/src/test/kotlin/lightOrgan/input/AudioInputManagerTests.kt
+++ b/src/test/kotlin/lightOrgan/input/AudioInputManagerTests.kt
@@ -87,27 +87,6 @@ class AudioInputManagerTests {
         assertEquals(otherInput.details, sut.inputDetails.value)
     }
 
-    // Input selection
-    @Test
-    fun `select the default input`() = runTest {
-        val sut = createSUT()
-
-        sut.selectDefaultInput()
-        sutScope.advanceUntilIdle()
-
-        assertEquals(defaultInput.details, sut.inputDetails.value)
-    }
-
-    @Test
-    fun `given an input was already selected, then selecting the default stops the previous input`() {
-        val sut = createSUT()
-        currentAudioInputFlow.value = otherInput.mock
-
-        sut.selectDefaultInput()
-
-        verify { otherInput.mock.stop() }
-    }
-
     // Start listening
     @Test
     fun `start listening to the current input`() {
@@ -120,7 +99,17 @@ class AudioInputManagerTests {
     }
 
     @Test
-    fun `given there is no input, then starting throws an error`() {
+    fun `given there is no input, then starting auto-selects the default`() {
+        val sut = createSUT()
+
+        sut.startListening()
+
+        verify { defaultInput.mock.start() }
+    }
+
+    @Test
+    fun `given there is no input and no default is found, then starting throws an error`() {
+        every { audioInputFinder.findDefaultInput() } returns null
         val sut = createSUT()
 
         assertThrows<IllegalStateException> { sut.startListening() }

--- a/src/test/kotlin/toolkit/junit/DisableLoggingExtension.kt
+++ b/src/test/kotlin/toolkit/junit/DisableLoggingExtension.kt
@@ -1,11 +1,12 @@
 package toolkit.junit
 
+import logging.LogLevel
 import logging.Logger
 import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 
 class DisableLoggingExtension : BeforeAllCallback {
     override fun beforeAll(context: ExtensionContext) {
-        Logger.enabled = false
+        Logger.level = LogLevel.OFF
     }
 }


### PR DESCRIPTION
On calling start, the input manager will attempt to find the default input. This reduces the number of calls to get to a working state and I can't think of any reason why we wouldn't want this.

I also fixed a flakey test and removed logging from tests (oversight from my last PR)