### PR TITLE
Updating how the config is passed through the spectral analysis stages

### DIFF
--- a/src/main/kotlin/config/AppConfig.kt
+++ b/src/main/kotlin/config/AppConfig.kt
@@ -3,7 +3,7 @@ package config
 import lightOrgan.gateway.GatewayConfig
 import lightOrgan.spectralAnalysis.SpectralAnalysisConfig
 
-class AppConfig(
+data class AppConfig(
     val spectralAnalysis: SpectralAnalysisConfig,
     val gateway: GatewayConfig
 )

--- a/src/main/kotlin/config/DefaultAppConfig.kt
+++ b/src/main/kotlin/config/DefaultAppConfig.kt
@@ -5,6 +5,7 @@ import dsp.filtering.FilterFamily
 import dsp.filtering.FilterOrder
 import dsp.windowing.WindowType
 import lightOrgan.gateway.GatewayConfig
+import lightOrgan.spectralAnalysis.AudioConditionerConfig
 import lightOrgan.spectralAnalysis.SpectralAnalysisConfig
 import lightOrgan.spectralAnalysis.peaks.PeakExtractorConfig
 import music.WesternTuningSystem
@@ -16,21 +17,23 @@ private val tuning = WesternTuningSystem()
 
 val DefaultAppConfig = AppConfig(
     spectralAnalysis = SpectralAnalysisConfig(
-        gainDb = 12f,
+        audioConditioner = AudioConditionerConfig(
+            gainDb = 12f,
+            highPassFilter = FilterConfig.HighPass(
+                frequency = tuning.getFrequency(tuning.A, octave = 0),
+                family = FilterFamily.Butterworth(FilterOrder.fromDbPerOctave(48)),
+            ),
+            lowPassFilter = FilterConfig.LowPass(
+                frequency = tuning.getFrequency(tuning.A, octave = 2),
+                family = FilterFamily.Butterworth(FilterOrder.fromDbPerOctave(48)),
+            ),
+            rolloffThreshold = -48f,
+            decimate = true
+        ),
         frameDuration = 63.milliseconds,
         approximateBinSpacing = 1f,
-        rolloffThreshold = -48f,
-        highPassFilter = FilterConfig.HighPass(
-            frequency = tuning.getFrequency(tuning.A, octave = 0),
-            family = FilterFamily.Butterworth(FilterOrder.fromDbPerOctave(48)),
-        ),
-        lowPassFilter = FilterConfig.LowPass(
-            frequency = tuning.getFrequency(tuning.A, octave = 2),
-            family = FilterFamily.Butterworth(FilterOrder.fromDbPerOctave(48)),
-        ),
         window = WindowType.BlackmanHarris3Term,
         peakExtractor = PeakExtractorConfig.Parabolic,
-        decimate = true
     ),
     gateway = GatewayConfig(
         autoReconnect = true,

--- a/src/main/kotlin/lightOrgan/spectralAnalysis/SpectralAnalysisConfig.kt
+++ b/src/main/kotlin/lightOrgan/spectralAnalysis/SpectralAnalysisConfig.kt
@@ -15,7 +15,7 @@ data class SpectralAnalysisConfig(
 
 data class AudioConditionerConfig(
     val gainDb: Float,
-    val rolloffThreshold: Float,
+    val rolloffThreshold: Float, // e.g. -48 dBFS
     val highPassFilter: FilterConfig.HighPass?,
     val lowPassFilter: FilterConfig.LowPass?,
     val decimate: Boolean,

--- a/src/main/kotlin/lightOrgan/spectralAnalysis/SpectralAnalysisConfig.kt
+++ b/src/main/kotlin/lightOrgan/spectralAnalysis/SpectralAnalysisConfig.kt
@@ -6,13 +6,17 @@ import lightOrgan.spectralAnalysis.peaks.PeakExtractorConfig
 import kotlin.time.Duration
 
 data class SpectralAnalysisConfig(
-    val gainDb: Float,  // e.g. 12 dBFS
+    val audioConditioner: AudioConditionerConfig,
     val frameDuration: Duration,
     val approximateBinSpacing: Float,
-    val rolloffThreshold: Float, // e.g. -48 dBFS
+    val window: WindowType,
+    val peakExtractor: PeakExtractorConfig
+)
+
+data class AudioConditionerConfig(
+    val gainDb: Float,
+    val rolloffThreshold: Float,
     val highPassFilter: FilterConfig.HighPass?,
     val lowPassFilter: FilterConfig.LowPass?,
-    val window: WindowType,
-    val peakExtractor: PeakExtractorConfig,
-    val decimate: Boolean
+    val decimate: Boolean,
 )

--- a/src/main/kotlin/lightOrgan/spectralAnalysis/SpectralAnalyzer.kt
+++ b/src/main/kotlin/lightOrgan/spectralAnalysis/SpectralAnalyzer.kt
@@ -1,7 +1,6 @@
 package lightOrgan.spectralAnalysis
 
 import audio.samples.AudioFrame
-import config.AppConfigSingleton
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -11,10 +10,9 @@ import lightOrgan.spectralAnalysis.spectrum.SpectrumCalculator
 
 // ENHANCEMENT: Split between short duration FFT (for brightness) and long duration FFT (for hue).
 class SpectralAnalyzer(
-    private val config: SpectralAnalysisConfig = AppConfigSingleton.value.spectralAnalysis,
-    private val audioConditioner: AudioConditioner = AudioConditioner(config),
-    private val spectrumCalculator: SpectrumCalculator = SpectrumCalculator(config),
-    private val peakExtractor: PeakExtractor = PeakExtractor(config)
+    private val audioConditioner: AudioConditioner = AudioConditioner(),
+    private val spectrumCalculator: SpectrumCalculator = SpectrumCalculator(),
+    private val peakExtractor: PeakExtractor = PeakExtractor()
 ) {
 
     private val _analysis = MutableStateFlow(SpectralAnalysis.EMPTY)

--- a/src/main/kotlin/lightOrgan/spectralAnalysis/conditioning/AudioConditioner.kt
+++ b/src/main/kotlin/lightOrgan/spectralAnalysis/conditioning/AudioConditioner.kt
@@ -1,15 +1,16 @@
 package lightOrgan.spectralAnalysis.conditioning
 
 import audio.samples.AudioFrame
+import config.AppConfigSingleton
 import dsp.Decimator
 import dsp.Gain
 import dsp.MonoMixer
 import dsp.filtering.Passband
 import dsp.filtering.StatefulFilter
-import lightOrgan.spectralAnalysis.SpectralAnalysisConfig
+import lightOrgan.spectralAnalysis.AudioConditionerConfig
 
 class AudioConditioner(
-    private val config: SpectralAnalysisConfig,
+    private val config: AudioConditionerConfig = AppConfigSingleton.value.spectralAnalysis.audioConditioner,
     private val monoMixer: MonoMixer = MonoMixer(),
     private val gain: Gain = Gain(),
     private val filterFactory: FilterFactory = FilterFactory(),
@@ -20,10 +21,12 @@ class AudioConditioner(
     private val lowPassFilter: StatefulFilter? = config.lowPassFilter?.let { filterFactory.create(it) }
 
     val passband: Passband
-        get() = Passband(
-            lowerFrequency = highPassFilter?.frequencyAt(config.rolloffThreshold) ?: 0f,
-            higherFrequency = lowPassFilter?.frequencyAt(config.rolloffThreshold) ?: Float.POSITIVE_INFINITY,
-        )
+        get() {
+            return Passband(
+                lowerFrequency = config.highPassFilter?.frequencyAt(config.rolloffThreshold) ?: 0f,
+                higherFrequency = config.lowPassFilter?.frequencyAt(config.rolloffThreshold) ?: Float.POSITIVE_INFINITY,
+            )
+        }
 
     fun condition(audio: AudioFrame): AudioFrame {
         var conditionedAudio = audio

--- a/src/main/kotlin/lightOrgan/spectralAnalysis/peaks/PeakExtractor.kt
+++ b/src/main/kotlin/lightOrgan/spectralAnalysis/peaks/PeakExtractor.kt
@@ -1,5 +1,6 @@
 package lightOrgan.spectralAnalysis.peaks
 
+import config.AppConfigSingleton
 import dsp.bins.FrequencyBins
 import dsp.peakExtraction.ParabolicSpectralPeakExtractor
 import dsp.peakExtraction.SpectralPeakExtractor
@@ -7,7 +8,7 @@ import dsp.peakExtraction.SpectralPeaks
 import lightOrgan.spectralAnalysis.SpectralAnalysisConfig
 
 class PeakExtractor(
-    private val config: SpectralAnalysisConfig,
+    private val config: SpectralAnalysisConfig = AppConfigSingleton.value.spectralAnalysis,
     private val extractor: SpectralPeakExtractor = createExtractor(config.peakExtractor)
 ) {
 

--- a/src/main/kotlin/lightOrgan/spectralAnalysis/spectrum/SpectrumCalculator.kt
+++ b/src/main/kotlin/lightOrgan/spectralAnalysis/spectrum/SpectrumCalculator.kt
@@ -3,6 +3,7 @@ package lightOrgan.spectralAnalysis.spectrum
 import audio.samples.AudioFormat
 import audio.samples.AudioFrame
 import audio.samples.RollingAudioBuffer
+import config.AppConfigSingleton
 import dsp.ZeroPaddingInterpolator
 import dsp.bins.FftFrequencyBinsCalculator
 import dsp.bins.FrequencyBins
@@ -16,7 +17,7 @@ import math.nextPowerOfTwo
 // ENHANCEMENT: Multi-resolution bin generations
 // ENHANCEMENT: Implement equal-loudness contours (ISO 226:2003). Manual SPL number with future plans of external meter?
 class SpectrumCalculator(
-    private val config: SpectralAnalysisConfig,
+    private val config: SpectralAnalysisConfig = AppConfigSingleton.value.spectralAnalysis,
     private val audioBuffer: RollingAudioBuffer = RollingAudioBuffer(),
     private val window: Window = config.window.createWindow(),
     private val interpolator: ZeroPaddingInterpolator = ZeroPaddingInterpolator(),

--- a/src/test/kotlin/lightOrgan/spectralAnalysis/SpectralAnalyzerIntegrationTests.kt
+++ b/src/test/kotlin/lightOrgan/spectralAnalysis/SpectralAnalyzerIntegrationTests.kt
@@ -2,30 +2,36 @@ package lightOrgan.spectrum
 
 import audio.samples.AudioFormat
 import audio.samples.AudioFrame
+import config.AppConfigSingleton
 import dsp.windowing.WindowType
+import lightOrgan.spectralAnalysis.AudioConditionerConfig
 import lightOrgan.spectralAnalysis.SpectralAnalysisConfig
 import lightOrgan.spectralAnalysis.SpectralAnalyzer
 import lightOrgan.spectralAnalysis.peaks.PeakExtractorConfig
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import toolkit.generators.combineWaves
 import toolkit.generators.generateSilence
 import toolkit.generators.generateSineWave
+import toolkit.monkeyTest.nextAppConfig
 import kotlin.math.abs
 import kotlin.time.Duration.Companion.milliseconds
 
 class SpectralAnalyzerIntegrationTests {
 
     private val config = SpectralAnalysisConfig(
-        gainDb = 0f,
+        audioConditioner = AudioConditionerConfig(
+            gainDb = 0f,
+            highPassFilter = null,
+            lowPassFilter = null,
+            rolloffThreshold = -48f,
+            decimate = true
+        ),
         frameDuration = 50.milliseconds, // 20 Hz spacing
         approximateBinSpacing = 1f,
-        rolloffThreshold = -48f,
-        highPassFilter = null,
-        lowPassFilter = null,
         window = WindowType.Hann,
         peakExtractor = PeakExtractorConfig.Parabolic,
-        decimate = true
     )
 
     private val audioFormat = AudioFormat(48000f, 16, 1)
@@ -38,9 +44,12 @@ class SpectralAnalyzerIntegrationTests {
     private val wave1Frame = AudioFrame(wave1.waveForm.samples, audioFormat)
     private val combinedWavesFrame = AudioFrame(combinedWaves.samples, audioFormat)
 
-    private fun createSUT(config: SpectralAnalysisConfig = this.config): SpectralAnalyzer {
-        return SpectralAnalyzer(config)
+    @BeforeEach
+    fun setupHappyPath() {
+        AppConfigSingleton.value = nextAppConfig().copy(spectralAnalysis = config)
     }
+
+    private fun createSUT() = SpectralAnalyzer()
 
     // Spectrum
     @Test

--- a/src/test/kotlin/lightOrgan/spectralAnalysis/SpectralAnalyzerUnitTests.kt
+++ b/src/test/kotlin/lightOrgan/spectralAnalysis/SpectralAnalyzerUnitTests.kt
@@ -55,7 +55,6 @@ class SpectralAnalyzerUnitTests {
 
     private fun createSUT(): SpectralAnalyzer {
         return SpectralAnalyzer(
-            config,
             audioConditioner,
             spectrumCalculator,
             peakExtractor

--- a/src/test/kotlin/lightOrgan/spectralAnalysis/conditioning/AudioConditionerTests.kt
+++ b/src/test/kotlin/lightOrgan/spectralAnalysis/conditioning/AudioConditionerTests.kt
@@ -7,7 +7,7 @@ import dsp.filtering.StatefulFilter
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
-import lightOrgan.spectralAnalysis.SpectralAnalysisConfig
+import lightOrgan.spectralAnalysis.AudioConditionerConfig
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
@@ -16,10 +16,11 @@ import toolkit.monkeyTest.*
 
 class AudioConditionerTests {
 
-    private val minimalConfig = nextSpectralAnalysisConfig().copy(
+    private val minimalConfig = AudioConditionerConfig(
         gainDb = 0f,
         highPassFilter = null,
         lowPassFilter = null,
+        rolloffThreshold = -3f,
         decimate = false
     )
 
@@ -36,11 +37,10 @@ class AudioConditionerTests {
 
     private val highPassConfig = nextHighPassConfig()
     private val highPassFilter: StatefulFilter = mockk()
-    private val lowerFrequency = 100f
 
     private val lowPassConfig = nextLowPassConfig()
     private val lowPassFilter: StatefulFilter = mockk()
-    private val upperFrequency = 1000f
+    private val lowPassStopFreq = lowPassConfig.frequencyAt(minimalConfig.rolloffThreshold)
 
     private val filteredSamples = nextFloatArray()
 
@@ -50,14 +50,12 @@ class AudioConditionerTests {
         every { gain.apply(monoAudio.samples, 3f) } returns gainedSamples
 
         every { filterFactory.create(highPassConfig) } returns highPassFilter
-        every { highPassFilter.frequencyAt(minimalConfig.rolloffThreshold) } returns lowerFrequency
         every { highPassFilter.filter(monoAudio.samples, monoAudio.format.sampleRate) } returns filteredSamples
 
         every { filterFactory.create(lowPassConfig) } returns lowPassFilter
-        every { lowPassFilter.frequencyAt(minimalConfig.rolloffThreshold) } returns upperFrequency
         every { lowPassFilter.filter(monoAudio.samples, monoAudio.format.sampleRate) } returns filteredSamples
 
-        every { decimator.decimationFactor(monoAudio.format.sampleRate, upperFrequency) } returns decimationFactor
+        every { decimator.decimationFactor(monoAudio.format.sampleRate, lowPassStopFreq) } returns decimationFactor
         every { decimator.decimate(monoAudio.copy(samples = filteredSamples), decimationFactor) } returns decimatedAudio
     }
 
@@ -66,8 +64,14 @@ class AudioConditionerTests {
         clearAllMocks()
     }
 
-    private fun createSUT(config: SpectralAnalysisConfig = minimalConfig): AudioConditioner {
-        return AudioConditioner(config, monoMixer, gain, filterFactory, decimator)
+    private fun createSUT(config: AudioConditionerConfig = minimalConfig): AudioConditioner {
+        return AudioConditioner(
+            config,
+            monoMixer,
+            gain,
+            filterFactory,
+            decimator
+        )
     }
 
     @Test
@@ -114,7 +118,11 @@ class AudioConditionerTests {
     @Test
     fun `given a high pass filter, passband lower frequency is the rolloff`() {
         val sut = createSUT(minimalConfig.copy(highPassFilter = highPassConfig))
-        assertEquals(lowerFrequency, sut.passband.lowerFrequency)
+
+        assertEquals(
+            highPassConfig.frequencyAt(minimalConfig.rolloffThreshold),
+            sut.passband.lowerFrequency
+        )
     }
 
     @Test
@@ -126,7 +134,11 @@ class AudioConditionerTests {
     @Test
     fun `given a low pass filter, passband upper frequency is the rolloff`() {
         val sut = createSUT(minimalConfig.copy(lowPassFilter = lowPassConfig))
-        assertEquals(upperFrequency, sut.passband.higherFrequency)
+
+        assertEquals(
+            lowPassConfig.frequencyAt(minimalConfig.rolloffThreshold),
+            sut.passband.higherFrequency
+        )
     }
 
     @Test

--- a/src/test/kotlin/toolkit/monkeyTest/NextSpectralAnalysisConfig.kt
+++ b/src/test/kotlin/toolkit/monkeyTest/NextSpectralAnalysisConfig.kt
@@ -1,19 +1,26 @@
 package toolkit.monkeyTest
 
 import dsp.windowing.WindowType
+import lightOrgan.spectralAnalysis.AudioConditionerConfig
 import lightOrgan.spectralAnalysis.SpectralAnalysisConfig
 import kotlin.random.Random
 
 fun nextSpectralAnalysisConfig(): SpectralAnalysisConfig {
     return SpectralAnalysisConfig(
-        gainDb = nextPositiveFloat(),
+        audioConditioner = nextAudioConditionerConfig(),
         frameDuration = nextDuration(),
         approximateBinSpacing = nextPositiveFloat(),
-        rolloffThreshold = nextPositiveFloat(),
-        highPassFilter = nextHighPassConfig(),
-        lowPassFilter = nextLowPassConfig(),
         window = nextEnum<WindowType>(),
         peakExtractor = nextPeakExtractorConfig(),
+    )
+}
+
+fun nextAudioConditionerConfig(): AudioConditionerConfig {
+    return AudioConditionerConfig(
+        gainDb = nextPositiveFloat(),
+        highPassFilter = nextHighPassConfig(),
+        lowPassFilter = nextLowPassConfig(),
+        rolloffThreshold = nextPositiveFloat(),
         decimate = Random.nextBoolean()
     )
 }


### PR DESCRIPTION
This lays the groundwork for config changes.

One minor downside - now the integration tests must update the config singleton instead of passing it through the SpectralAnalyzer constructor, but that is more representative of how the config is exposed throughout the project. The alternative is basically every constructor taking a config, if not for itself than for its dependencies, which is smelly in its own way.